### PR TITLE
Add testimonials carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,26 @@
         <section id="services" class="services">
             <!-- Service cards will be injected here -->
         </section>
+
+        <section id="testimonials" class="testimonials">
+            <h2>Testimonials</h2>
+            <div class="testimonial-carousel">
+                <div class="testimonial active">
+                    <p>"Baayno transformed our business!"</p>
+                    <h4>- Alex</h4>
+                </div>
+                <div class="testimonial">
+                    <p>"Their team is incredibly talented."</p>
+                    <h4>- Jamie</h4>
+                </div>
+                <div class="testimonial">
+                    <p>"Outstanding service and support."</p>
+                    <h4>- Casey</h4>
+                </div>
+                <button id="prev-testimonial" class="carousel-btn prev">&#10094;</button>
+                <button id="next-testimonial" class="carousel-btn next">&#10095;</button>
+            </div>
+        </section>
     </main>
     <footer>
         <p>&copy; 2025 Baayno Website</p>

--- a/script.js
+++ b/script.js
@@ -39,4 +39,55 @@ document.addEventListener('DOMContentLoaded', () => {
             servicesSection.appendChild(article);
         });
     }
+
+    const testimonials = document.querySelectorAll('#testimonials .testimonial');
+    const nextBtn = document.getElementById('next-testimonial');
+    const prevBtn = document.getElementById('prev-testimonial');
+    let currentIndex = 0;
+    const intervalTime = 5000;
+    let intervalId;
+
+    function showTestimonial(index) {
+        testimonials.forEach((testimonial, i) => {
+            testimonial.classList.toggle('active', i === index);
+        });
+    }
+
+    function nextTestimonial() {
+        currentIndex = (currentIndex + 1) % testimonials.length;
+        showTestimonial(currentIndex);
+    }
+
+    function prevTestimonial() {
+        currentIndex = (currentIndex - 1 + testimonials.length) % testimonials.length;
+        showTestimonial(currentIndex);
+    }
+
+    function startInterval() {
+        intervalId = setInterval(nextTestimonial, intervalTime);
+    }
+
+    function resetInterval() {
+        clearInterval(intervalId);
+        startInterval();
+    }
+
+    if (nextBtn) {
+        nextBtn.addEventListener('click', () => {
+            nextTestimonial();
+            resetInterval();
+        });
+    }
+
+    if (prevBtn) {
+        prevBtn.addEventListener('click', () => {
+            prevTestimonial();
+            resetInterval();
+        });
+    }
+
+    if (testimonials.length) {
+        showTestimonial(currentIndex);
+        startInterval();
+    }
 });

--- a/style.css
+++ b/style.css
@@ -106,6 +106,56 @@ main {
 .card h3 {
     margin-top: 0;
 }
+
+.testimonials {
+    margin-top: 2em;
+}
+
+.testimonial-carousel {
+    position: relative;
+    max-width: 500px;
+    margin: 0 auto;
+    min-height: 180px;
+}
+
+.testimonial {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 1em;
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    opacity: 0;
+    transition: opacity 0.5s ease;
+}
+
+.testimonial.active {
+    position: relative;
+    opacity: 1;
+}
+
+.carousel-btn {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    background: rgba(0, 0, 0, 0.5);
+    color: #fff;
+    border: none;
+    border-radius: 50%;
+    width: 30px;
+    height: 30px;
+    cursor: pointer;
+}
+
+.carousel-btn.prev {
+    left: 10px;
+}
+
+.carousel-btn.next {
+    right: 10px;
+}
 button {
     padding: 0.5em 1em;
     font-size: 1em;


### PR DESCRIPTION
## Summary
- add testimonial section with carousel controls
- style carousel cards with consistent dimensions and transitions
- implement auto-rotating testimonial logic with manual navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a57fdb8a94832ebadc6e2397631c68