### PR TITLE
Add contact form with validation

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,28 @@
             <!-- Service cards will be injected here -->
         </section>
 
+        <section id="contact" class="contact">
+            <h2>Contact Us</h2>
+            <form id="contact-form" class="contact-form" novalidate>
+                <div class="form-group">
+                    <label for="name">Name</label>
+                    <input type="text" id="name" name="name">
+                    <span id="name-error" class="error-message"></span>
+                </div>
+                <div class="form-group">
+                    <label for="email">Email</label>
+                    <input type="email" id="email" name="email">
+                    <span id="email-error" class="error-message"></span>
+                </div>
+                <div class="form-group">
+                    <label for="message">Message</label>
+                    <textarea id="message" name="message"></textarea>
+                    <span id="message-error" class="error-message"></span>
+                </div>
+                <button type="submit">Send</button>
+            </form>
+        </section>
+
         <section id="testimonials" class="testimonials">
             <h2>Testimonials</h2>
             <div class="testimonial-carousel">

--- a/script.js
+++ b/script.js
@@ -90,4 +90,46 @@ document.addEventListener('DOMContentLoaded', () => {
         showTestimonial(currentIndex);
         startInterval();
     }
+
+    const contactForm = document.getElementById('contact-form');
+    if (contactForm) {
+        contactForm.addEventListener('submit', (e) => {
+            e.preventDefault();
+            let valid = true;
+            const nameInput = document.getElementById('name');
+            const emailInput = document.getElementById('email');
+            const messageInput = document.getElementById('message');
+            const nameError = document.getElementById('name-error');
+            const emailError = document.getElementById('email-error');
+            const messageError = document.getElementById('message-error');
+
+            nameError.textContent = '';
+            emailError.textContent = '';
+            messageError.textContent = '';
+
+            if (!nameInput.value.trim()) {
+                nameError.textContent = 'Name is required.';
+                valid = false;
+            }
+
+            const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+            if (!emailInput.value.trim()) {
+                emailError.textContent = 'Email is required.';
+                valid = false;
+            } else if (!emailPattern.test(emailInput.value.trim())) {
+                emailError.textContent = 'Enter a valid email.';
+                valid = false;
+            }
+
+            if (!messageInput.value.trim()) {
+                messageError.textContent = 'Message is required.';
+                valid = false;
+            }
+
+            if (valid) {
+                contactForm.reset();
+                alert('Thank you for your message!');
+            }
+        });
+    }
 });

--- a/style.css
+++ b/style.css
@@ -107,6 +107,46 @@ main {
     margin-top: 0;
 }
 
+.contact {
+    margin-top: 2em;
+}
+
+.contact-form {
+    max-width: 500px;
+    margin: 0 auto;
+}
+
+.form-group {
+    margin-bottom: 1em;
+    text-align: left;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 0.5em;
+}
+
+.form-group input,
+.form-group textarea {
+    width: 100%;
+    padding: 0.5em;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-family: inherit;
+}
+
+.form-group textarea {
+    resize: vertical;
+    min-height: 120px;
+}
+
+.error-message {
+    display: block;
+    color: red;
+    font-size: 0.875em;
+    margin-top: 0.25em;
+}
+
 .testimonials {
     margin-top: 2em;
 }


### PR DESCRIPTION
## Summary
- add contact form section to homepage
- style contact form to match existing theme
- validate form fields and show helpful error messages

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a580e27e64832e9a1ee81cb6f4e294