### PR TITLE
Add services section grid and dynamic cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,10 +27,8 @@
     </section>
     <main>
         <p>This is your starter project. Begin building here!</p>
-        <section id="services" class="services">
-            <div class="container">
-                <!-- Service cards will be injected here -->
-            </div>
+        <section id="services" class="services container">
+            <!-- Service cards will be injected here -->
         </section>
 
         <section id="contact" class="contact">

--- a/script.js
+++ b/script.js
@@ -43,16 +43,32 @@ document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('section').forEach(section => observer.observe(section));
 
     const servicesData = [
-        { title: 'Web Development', description: 'Modern and responsive websites.' },
-        { title: 'UI/UX Design', description: 'Intuitive and engaging designs.' },
-        { title: 'Consulting', description: 'Expert guidance for your projects.' }
+        {
+            title: 'Web Development',
+            description: 'Modern and responsive websites.',
+            image: 'https://via.placeholder.com/300x150?text=Web+Dev'
+        },
+        {
+            title: 'UI/UX Design',
+            description: 'Intuitive and engaging designs.',
+            image: 'https://via.placeholder.com/300x150?text=UI+UX'
+        },
+        {
+            title: 'Consulting',
+            description: 'Expert guidance for your projects.'
+        }
     ];
-    const servicesSection = document.querySelector('.services .container');
+    const servicesSection = document.getElementById('services');
     if (servicesSection) {
         servicesData.forEach(service => {
             const article = document.createElement('article');
             article.className = 'card';
-            article.innerHTML = `<h3>${service.title}</h3><p>${service.description}</p>`;
+            let content = '';
+            if (service.image) {
+                content += `<img src="${service.image}" alt="${service.title}">`;
+            }
+            content += `<h3>${service.title}</h3><p>${service.description}</p>`;
+            article.innerHTML = content;
             servicesSection.appendChild(article);
         });
     }

--- a/style.css
+++ b/style.css
@@ -177,12 +177,9 @@ main {
 
 .services {
     margin-top: 2em;
-}
-
-.services .container {
     display: grid;
-    grid-template-columns: 1fr;
-    gap: 1.5em;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1.5rem;
 }
 
 .card {
@@ -191,6 +188,13 @@ main {
     border-radius: 8px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     transition: transform 0.3s, box-shadow 0.3s;
+}
+
+.card img {
+    width: 100%;
+    height: auto;
+    border-radius: var(--radius);
+    margin-bottom: 0.5rem;
 }
 
 .card:hover,
@@ -349,9 +353,6 @@ footer {
         font-size: 2rem;
     }
 
-    .services .container {
-        grid-template-columns: repeat(3, 1fr);
-    }
 
     .testimonial-carousel {
         display: grid;


### PR DESCRIPTION
## Summary
- Turn the Services section into a responsive grid for service cards
- Dynamically generate service cards from a data array with optional images
- Style service cards including optional image support

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a5ca706b34832ea8965c826ceaed6f