### PR TITLE
Enhance site branding and navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,30 +3,34 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Baayno Website</title>
+    <meta name="description" content="Baayno — Precision Bookbinding &amp; Finishing in Beirut, Lebanon.">
+    <meta property="og:title" content="Baayno — Precision Bookbinding &amp; Finishing">
+    <meta property="og:description" content="Custom binding, restoration, embossing and more in Beirut, Lebanon.">
+    <meta property="og:image" content="https://images.unsplash.com/photo-1588774067489-58fdc141094a?auto=format&amp;fit=crop&amp;w=1200&amp;q=80">
+    <link rel="icon" href="logo.svg" type="image/svg+xml">
+    <title>Baayno — Bookbinding &amp; Finishing</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body class="body-font">
     <header class="navbar">
         <a href="#" class="logo"><img src="logo.svg" alt="Fouad Baayno Bookbindery logo" loading="lazy"></a>
         <nav>
-            <ul class="nav-links">
-                <li><a href="#">Home</a></li>
+            <ul class="nav-links" id="nav-links">
+                <li><a href="#hero">Home</a></li>
                 <li><a href="#services">Services</a></li>
                 <li><a href="#contact">Contact</a></li>
             </ul>
         </nav>
-        <button id="nav-toggle" aria-label="Toggle navigation">&#9776;</button>
+        <button id="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false">&#9776;</button>
     </header>
-    <section class="hero">
+    <section class="hero" id="hero">
         <div class="hero-content container">
             <h1 class="heading-font">Handcrafted Bookbinding</h1>
-            <p>Preserving stories with artisan skill.</p>
-            <button id="request-quote">Request a Quote</button>
+            <p>Precision Bookbinding &amp; Finishing</p>
+            <button class="btn btn-primary" id="request-quote">Request a Quote</button>
         </div>
     </section>
     <main>
-        <p>This is your starter project. Begin building here!</p>
         <section id="quote" class="quote">
             <div class="container">
                 <h2 class="heading-font">Request a Quote</h2>
@@ -66,6 +70,7 @@
             </div>
         </section>
         <section id="services" class="services container">
+            <h2 class="heading-font">Services</h2>
             <!-- Service cards will be injected here -->
         </section>
 

--- a/script.js
+++ b/script.js
@@ -18,14 +18,16 @@ if (requestQuoteBtn) {
     });
 }
 
+const navToggle = document.getElementById('nav-toggle');
 function toggleNav() {
-    const navLinks = document.querySelector('.nav-links');
+    const navLinks = document.getElementById('nav-links');
+    const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+    navToggle.setAttribute('aria-expanded', String(!expanded));
     if (navLinks) {
         navLinks.classList.toggle('open');
     }
 }
 
-const navToggle = document.getElementById('nav-toggle');
 if (navToggle) {
     navToggle.addEventListener('click', toggleNav);
 }
@@ -33,10 +35,15 @@ if (navToggle) {
 const navItems = document.querySelectorAll('.nav-links a');
 if (navItems.length) {
     navItems.forEach(link => link.addEventListener('click', () => {
-        const navLinks = document.querySelector('.nav-links');
+        const navLinks = document.getElementById('nav-links');
         if (navLinks) {
             navLinks.classList.remove('open');
         }
+        if (navToggle) {
+            navToggle.setAttribute('aria-expanded', 'false');
+        }
+        navItems.forEach(l => l.classList.remove('active'));
+        link.classList.add('active');
     }));
 }
 
@@ -54,18 +61,34 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const servicesData = [
         {
-            title: 'Web Development',
-            description: 'Modern and responsive websites.',
-            image: 'https://via.placeholder.com/300x150?text=Web+Dev'
+            icon: '📚',
+            title: 'Hardcover Binding',
+            description: 'Durable covers for premium books.'
         },
         {
-            title: 'UI/UX Design',
-            description: 'Intuitive and engaging designs.',
-            image: 'https://via.placeholder.com/300x150?text=UI+UX'
+            icon: '📘',
+            title: 'Perfect/PUR Binding',
+            description: 'Clean, professional softcover books.'
         },
         {
-            title: 'Consulting',
-            description: 'Expert guidance for your projects.'
+            icon: '🛠️',
+            title: 'Restoration & Repair',
+            description: 'Give cherished books a new life.'
+        },
+        {
+            icon: '✨',
+            title: 'Foil & Embossing',
+            description: 'Custom finishes that stand out.'
+        },
+        {
+            icon: '🧪',
+            title: 'Short-Run Prototyping',
+            description: 'Test editions without large commitments.'
+        },
+        {
+            icon: '🏭',
+            title: 'Industrial Finishing',
+            description: 'High-volume finishing for publishers.'
         }
     ];
     const servicesSection = document.getElementById('services');
@@ -74,8 +97,8 @@ document.addEventListener('DOMContentLoaded', () => {
             const article = document.createElement('article');
             article.className = 'card';
             let content = '';
-            if (service.image) {
-                content += `<img src="${service.image}" alt="${service.title}">`;
+            if (service.icon) {
+                content += `<div class="icon">${service.icon}</div>`;
             }
             content += `<h3>${service.title}</h3><p>${service.description}</p>`;
             article.innerHTML = content;

--- a/style.css
+++ b/style.css
@@ -1,11 +1,12 @@
 @import url('https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&family=Open+Sans:wght@400;700&display=swap');
 
 :root {
-    --black: #000;
-    --white: #fff;
-    --accent: #c00;
-    --accent-dark: #900;
-    --radius: 4px;
+    --black: #0b0b0b;
+    --white: #ffffff;
+    --accent: #d61f26;
+    --accent-dark: #a3181e;
+    --gold: #c9a227;
+    --radius: 12px;
     --btn-padding: 0.75em 1.5em;
 }
 
@@ -46,7 +47,7 @@ section {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    background: var(--accent);
+    background: var(--black);
     color: var(--white);
     padding: 1em;
     flex-wrap: wrap;
@@ -76,29 +77,18 @@ section {
 .nav-links a {
     color: var(--white);
     text-decoration: none;
-    position: relative;
-    transition: color 0.3s;
-}
-
-.nav-links a::after {
-    content: '';
-    position: absolute;
-    left: 0;
-    bottom: -4px;
-    width: 0;
-    height: 2px;
-    background: var(--white);
-    transition: width 0.3s;
+    padding-bottom: 2px;
+    border-bottom: 2px solid transparent;
+    transition: color 0.3s, border-color 0.3s;
 }
 
 .nav-links a:hover,
 .nav-links a:focus {
-    color: #ffe6d4;
+    color: var(--accent);
 }
 
-.nav-links a:hover::after,
-.nav-links a:focus::after {
-    width: 100%;
+.nav-links a.active {
+    border-color: var(--gold);
 }
 
 #nav-toggle {
@@ -119,7 +109,7 @@ section {
     align-items: center;
     color: var(--white);
     height: 100vh;
-    background: url('https://images.unsplash.com/photo-1519682337058-a94d519337bc?auto=format&fit=crop&w=1200&q=80') center/cover no-repeat;
+    background: url('https://images.unsplash.com/photo-1588774067489-58fdc141094a?auto=format&fit=crop&w=1600&q=80') center/cover no-repeat;
 }
 
 .hero .container {
@@ -185,8 +175,9 @@ main {
 .card {
     background: var(--white);
     padding: 1em;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    border-radius: var(--radius);
+    border-top: 4px solid var(--accent);
+    box-shadow: var(--shadow, 0 2px 4px rgba(0, 0, 0, 0.1));
     transition: all 0.3s ease;
 }
 
@@ -194,6 +185,11 @@ main {
     width: 100%;
     height: auto;
     border-radius: var(--radius);
+    margin-bottom: 0.5rem;
+}
+
+.card .icon {
+    font-size: 2rem;
     margin-bottom: 0.5rem;
 }
 
@@ -324,6 +320,26 @@ button {
     transition: all 0.3s ease;
 }
 
+.btn {
+    display: inline-block;
+    padding: var(--btn-padding);
+    border-radius: var(--radius);
+    border: 2px solid transparent;
+    cursor: pointer;
+    transition: background 0.3s, color 0.3s, transform 0.3s;
+}
+
+.btn-primary {
+    background: var(--accent);
+    color: var(--white);
+}
+
+.btn-primary:hover,
+.btn-primary:focus {
+    background: var(--accent-dark);
+    transform: translateY(-2px);
+}
+
 button:hover,
 button:focus {
     background: var(--accent-dark);
@@ -403,7 +419,7 @@ footer {
         display: none;
         flex-direction: column;
         width: 100%;
-        background: var(--accent);
+        background: var(--black);
         margin-top: 1em;
     }
 


### PR DESCRIPTION
## Summary
- add SEO meta tags, favicon, and accessible navigation controls
- update styling to match brand colors and improve service cards
- populate services grid with real bookbinding offerings and nav toggle aria support

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a571e39e68832e81b832a341a8e996