### PR TITLE
Add sticky header and active navigation highlighting

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,17 +12,21 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body class="body-font">
-    <header class="navbar">
-        <a href="#" class="logo"><img src="logo.svg" alt="Fouad Baayno Bookbindery logo" loading="lazy"></a>
-        <nav>
-            <ul class="nav-links" id="nav-links">
-                <li><a href="#hero">Home</a></li>
-                <li><a href="#services">Services</a></li>
-                <li><a href="#contact">Contact</a></li>
-            </ul>
-        </nav>
-        <button id="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false">&#9776;</button>
-    </header>
+    <div class="sticky-header">
+        <header class="navbar">
+            <a href="#" class="logo"><img src="logo.svg" alt="Fouad Baayno Bookbindery logo" loading="lazy"></a>
+            <nav>
+                <ul class="nav-links" id="nav-links">
+                    <li><a href="#hero">Home</a></li>
+                    <li><a href="#services">Services</a></li>
+                    <li><a href="#portfolio">Portfolio</a></li>
+                    <li><a href="#blog">Blog</a></li>
+                    <li><a href="#contact">Contact</a></li>
+                </ul>
+            </nav>
+            <button id="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded="false">&#9776;</button>
+        </header>
+    </div>
     <section class="hero" id="hero">
         <div class="hero-content container">
             <h1 class="heading-font">Handcrafted Bookbinding</h1>
@@ -102,6 +106,16 @@
                     <figcaption>Foil stamping on leather spine</figcaption>
                 </figure>
             </div>
+        </section>
+
+        <section id="portfolio" class="portfolio container">
+            <h2 class="heading-font">Portfolio</h2>
+            <p>Our latest projects will appear here.</p>
+        </section>
+
+        <section id="blog" class="blog container">
+            <h2 class="heading-font">Blog</h2>
+            <p>Insights and updates coming soon.</p>
         </section>
 
         <section id="contact" class="contact">

--- a/script.js
+++ b/script.js
@@ -48,6 +48,20 @@ if (navItems.length) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+    const sections = document.querySelectorAll('section[id]');
+    if (sections.length && navItems.length) {
+        const sectionObserver = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    navItems.forEach(link => {
+                        link.classList.toggle('active', link.getAttribute('href') === `#${entry.target.id}`);
+                    });
+                }
+            });
+        }, { threshold: 0.6 });
+        sections.forEach(section => sectionObserver.observe(section));
+    }
+
     const observer = new IntersectionObserver((entries, obs) => {
         entries.forEach(entry => {
             if (entry.isIntersecting) {

--- a/style.css
+++ b/style.css
@@ -48,6 +48,14 @@ section {
     padding: 0 1em;
 }
 
+.sticky-header {
+    position: sticky;
+    top: 0;
+    z-index: 1000;
+    background: var(--color-black);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
 
 .navbar {
     display: flex;
@@ -94,6 +102,7 @@ section {
 }
 
 .nav-links a.active {
+    color: var(--color-accent);
     border-color: var(--color-gold);
 }
 


### PR DESCRIPTION
## Summary
- Wrap site navigation in a sticky container and add Portfolio & Blog links with placeholder sections
- Highlight active page section while closing mobile menu on link click
- Style sticky header and active nav states for better UX

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a60a108244832eaa5416ed9200f157