### PR TITLE
feat: add section fade-in observer

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,6 +1,29 @@
+import { useEffect } from 'react';
 import Navbar from './Navbar';
 
 export default function Layout({ children }) {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const sections = document.querySelectorAll('section');
+    const observer = new IntersectionObserver(
+      entries => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('fade-in');
+          }
+        });
+      },
+      { threshold: 0.1 }
+    );
+
+    sections.forEach(sec => observer.observe(sec));
+    return () => {
+      sections.forEach(sec => observer.unobserve(sec));
+      observer.disconnect();
+    };
+  }, []);
+
   return (
     <>
       <div className="sticky-header">


### PR DESCRIPTION
## Summary
- add IntersectionObserver to fade sections in on scroll

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a6cd88c5b8832eaf5947d61b3e7c98