### PR TITLE
fix: remove fade-in observer to show content

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "dev": "next dev",
+    "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "npm run lint"
   },
   "dependencies": {
     "react": "19.1.0",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -98,17 +98,6 @@ body {
     font-weight: var(--fw-normal);
 }
 
-section {
-    opacity: 0;
-    transform: translateY(20px);
-    transition: opacity 0.6s ease-out, transform 0.6s ease-out;
-}
-
-.fade-in {
-    opacity: 1;
-    transform: translateY(0);
-}
-
 .container {
     max-width: 1200px;
     margin: 0 auto;


### PR DESCRIPTION
## Summary
- remove layout's IntersectionObserver so sections render without being hidden
- drop fade-in CSS that set sections to opacity 0
- add npm test script that runs lint
- switch dev and build scripts to stable Next.js compiler to serve pages reliably

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a6cd88c5b8832eaf5947d61b3e7c98