### PR TITLE
Remove deprecated next export step

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/pages/b
   - `basePath: '/Baayno-Website'`
   - `assetPrefix: '/Baayno-Website/'`
   - (optional) `images: { unoptimized: true }` and `trailingSlash: true` for Pages.
-- Run `npm run build` (and `npx next export` if needed). This creates an `out/` folder with `index.html` and assets.
+- Run `npm run build`. This creates an `out/` folder with `index.html` and assets.
 - Deploy the contents of `out/` as your site root (GitHub Pages: serve `gh-pages` branch from `/`).
 - If you fork or rename the repo, update `basePath` and `assetPrefix` in `next.config.js` to match the new repo name.
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build && next export",
+    "build": "next build",
     "start": "next start",
     "lint": "eslint",
     "test": "npm run lint"


### PR DESCRIPTION
## Summary
- fix build script to use `next build` only
- update README deployment instructions

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a6f69014c0832e947f885c76b680f3