### PR TITLE
Use Next.js Image component with configured domains

### DIFF
--- a/components/Blog.js
+++ b/components/Blog.js
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import Image from 'next/image';
 
 export default function Blog({ posts = [] }) {
   return (
@@ -8,7 +9,13 @@ export default function Blog({ posts = [] }) {
         {posts.map((post) => (
           <article key={post.slug} className="card">
             {post.image && (
-              <img src={post.image} alt={post.title} loading="lazy" />
+              <Image
+                src={post.image}
+                alt={post.title}
+                width={600}
+                height={400}
+                style={{ width: '100%', height: 'auto' }}
+              />
             )}
             <h3>{post.title}</h3>
             <p>{post.description}</p>

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { useState } from 'react';
 import { useRouter } from 'next/router';
+import Image from 'next/image';
 
 export default function Navbar() {
   const [open, setOpen] = useState(false);
@@ -10,7 +11,12 @@ export default function Navbar() {
   return (
     <header className="navbar">
       <Link href="/" className="logo" onClick={close}>
-        <img src={`${router.basePath}/logo.svg`} alt="Fouad Baayno Bookbindery logo" loading="lazy" />
+        <Image
+          src={`${router.basePath}/logo.svg`}
+          alt="Fouad Baayno Bookbindery logo"
+          width={640}
+          height={289}
+        />
       </Link>
       <nav>
         <ul className={open ? 'nav-links open' : 'nav-links'}>

--- a/components/Portfolio.js
+++ b/components/Portfolio.js
@@ -1,3 +1,5 @@
+import Image from 'next/image';
+
 const portfolioData = [
   {
     img: 'https://images.unsplash.com/photo-1516979187457-637abb4f9353?auto=format&fit=crop&w=600&q=80',
@@ -23,7 +25,13 @@ export default function Portfolio() {
       <div className="portfolio-grid">
         {portfolioData.map((item, idx) => (
           <article key={idx} className="card">
-            <img src={item.img} alt={item.title} loading="lazy" />
+            <Image
+              src={item.img}
+              alt={item.title}
+              width={600}
+              height={400}
+              style={{ width: '100%', height: 'auto' }}
+            />
             <h3>{item.title}</h3>
             <p>{item.description}</p>
           </article>

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,7 +6,10 @@ const nextConfig = {
   reactStrictMode: true,
   output: 'export',
   trailingSlash: true,
-  images: { unoptimized: true },
+  images: {
+    unoptimized: true,
+    domains: ['images.unsplash.com'],
+  },
   basePath: isProd ? '/Baayno-Website' : undefined,
   assetPrefix: isProd ? '/Baayno-Website/' : undefined,
 };

--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import Image from 'next/image';
 import Layout from '@/components/Layout';
 import { getAllPostSlugs, getPostData } from '@/lib/posts';
 
@@ -11,7 +12,13 @@ export default function BlogPost({ post }) {
       <article className="container">
         <h1>{post.title}</h1>
         {post.image && (
-          <img src={post.image} alt={post.title} />
+          <Image
+            src={post.image}
+            alt={post.title}
+            width={600}
+            height={400}
+            style={{ width: '100%', height: 'auto' }}
+          />
         )}
         <div dangerouslySetInnerHTML={{ __html: post.content }} />
       </article>


### PR DESCRIPTION
## Summary
- replace `<img>` tags in navbar, blog list, blog posts, and portfolio components with `next/image` for optimized loading
- allow Unsplash-hosted images through `images.domains` config

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a718641bb0832e993b24c879f4d213