### PR TITLE
Add reusable SEO component and sitemap

### DIFF
--- a/components/SEO.js
+++ b/components/SEO.js
@@ -1,0 +1,18 @@
+import Head from 'next/head';
+
+export default function SEO({ title, description, canonical }) {
+  return (
+    <Head>
+      {title && <title>{title}</title>}
+      {description && <meta name="description" content={description} />}
+      {canonical && <link rel="canonical" href={canonical} />}
+      {title && <meta property="og:title" content={title} />}
+      {description && <meta property="og:description" content={description} />}
+      {canonical && <meta property="og:url" content={canonical} />}
+      <meta property="og:type" content="website" />
+      {title && <meta name="twitter:title" content={title} />}
+      {description && <meta name="twitter:description" content={description} />}
+      <meta name="twitter:card" content="summary_large_image" />
+    </Head>
+  );
+}

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -1,14 +1,15 @@
-import Head from 'next/head';
 import Layout from '@/components/Layout';
 import Blog from '@/components/Blog';
+import SEO from '@/components/SEO';
 import { getAllPosts } from '@/lib/posts';
 
 export default function BlogPage({ posts }) {
   return (
     <Layout>
-      <Head>
-        <title>Blog - Baayno</title>
-      </Head>
+      <SEO
+        title="Blog - Baayno"
+        canonical="https://www.baayno.com/blog"
+      />
       <Blog posts={posts} />
     </Layout>
   );

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -1,7 +1,7 @@
-import Head from 'next/head';
 import { useEffect, useState } from 'react';
 import Layout from '@/components/Layout';
 import ContactForm from '@/components/ContactForm';
+import SEO from '@/components/SEO';
 
 export default function ContactPage() {
   const [info, setInfo] = useState({ address: '', phones: [] });
@@ -15,9 +15,7 @@ export default function ContactPage() {
 
   return (
     <Layout>
-      <Head>
-        <title>Contact - Baayno</title>
-      </Head>
+      <SEO title="Contact - Baayno" canonical="https://www.baayno.com/contact" />
       <section id="contact" className="contact">
         <div className="container">
           <h2 className="heading-font">Contact Us</h2>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,5 @@
-import Head from 'next/head';
 import Layout from '@/components/Layout';
+import SEO from '@/components/SEO';
 import Hero from '@/components/Hero';
 import About from '@/components/About';
 import QuoteForm from '@/components/QuoteForm';
@@ -10,10 +10,11 @@ import Blog from '@/components/Blog';
 export default function Home() {
   return (
     <Layout>
-      <Head>
-        <title>Baayno — Bookbinding & Finishing</title>
-        <meta name="description" content="Precision bookbinding & finishing" />
-      </Head>
+      <SEO
+        title="Baayno — Bookbinding & Finishing"
+        description="Precision bookbinding & finishing"
+        canonical="https://www.baayno.com/"
+      />
       <Hero />
       <About />
       <QuoteForm />

--- a/pages/portfolio.js
+++ b/pages/portfolio.js
@@ -1,13 +1,14 @@
-import Head from 'next/head';
 import Layout from '@/components/Layout';
 import Portfolio from '@/components/Portfolio';
+import SEO from '@/components/SEO';
 
 export default function PortfolioPage() {
   return (
     <Layout>
-      <Head>
-        <title>Portfolio - Baayno</title>
-      </Head>
+      <SEO
+        title="Portfolio - Baayno"
+        canonical="https://www.baayno.com/portfolio"
+      />
       <Portfolio />
     </Layout>
   );

--- a/pages/services.js
+++ b/pages/services.js
@@ -1,13 +1,14 @@
-import Head from 'next/head';
 import Layout from '@/components/Layout';
 import Services from '@/components/Services';
+import SEO from '@/components/SEO';
 
 export default function ServicesPage() {
   return (
     <Layout>
-      <Head>
-        <title>Services - Baayno</title>
-      </Head>
+      <SEO
+        title="Services - Baayno"
+        canonical="https://www.baayno.com/services"
+      />
       <Services />
     </Layout>
   );

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.baayno.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.baayno.com/</loc>
+  </url>
+  <url>
+    <loc>https://www.baayno.com/services</loc>
+  </url>
+  <url>
+    <loc>https://www.baayno.com/portfolio</loc>
+  </url>
+  <url>
+    <loc>https://www.baayno.com/blog</loc>
+  </url>
+  <url>
+    <loc>https://www.baayno.com/contact</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- implement reusable SEO component and integrate across main pages
- add sitemap.xml and robots.txt for improved indexing

## Testing
- `npm test`
- `npm run build`
- `node -e "const ogs=require('open-graph-scraper');const fs=require('fs');ogs({html:fs.readFileSync('out/index.html','utf8')}).then(r=>console.log(JSON.stringify(r.result,null,2))).catch(err=>console.error(err));"`
- `curl -s -H "Content-Type: text/html; charset=utf-8" --data-binary @out/index.html https://validator.w3.org/nu/?out=json | jq '.messages | .[0]'`


------
https://chatgpt.com/codex/tasks/task_b_68a7199d15b0832e83522eae108189dc