### PR TITLE
Improve accessibility across components

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,10 @@ This site uses [next-pwa](https://github.com/shadowwalker/next-pwa) for offline 
 ### Refreshing the service worker
 
 After deploying a new version, hard refresh the page (Shift ↻) or use DevTools → Application → Service Workers → "Unregister" to force an update.
+
+## Accessibility Guidelines
+
+- All images use descriptive `alt` text.
+- Buttons and interactive elements include clear labels via visible text or `aria-label` attributes.
+- Form inputs indicate errors with `aria-invalid` and associated messages announced using `role="alert"`.
+- Status messages use `role="status"` and `aria-live` to be read by assistive technology.

--- a/components/Blog.tsx
+++ b/components/Blog.tsx
@@ -30,7 +30,9 @@ export default function Blog({ posts = [] }: BlogProps) {
             )}
             <h3>{post.title}</h3>
             <p>{post.description}</p>
-            <Link href={`/blog/${post.slug}`}>Read more</Link>
+            <Link href={`/blog/${post.slug}`} aria-label={`Read more about ${post.title}`}>
+              Read more
+            </Link>
           </article>
         ))}
       </div>

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -58,22 +58,68 @@ export default function ContactForm() {
     <form id="contact-form" className="contact-form" onSubmit={handleSubmit} noValidate>
       <div className="form-group">
         <label htmlFor="name">Name</label>
-        <input type="text" id="name" name="name" value={form.name} onChange={handleChange} />
-        {errors.name && <span id="name-error" className="error-message">{errors.name}</span>}
+        <input
+          type="text"
+          id="name"
+          name="name"
+          value={form.name}
+          onChange={handleChange}
+          aria-invalid={!!errors.name}
+          aria-describedby={errors.name ? 'name-error' : undefined}
+          required
+        />
+        {errors.name && (
+          <span id="name-error" className="error-message" role="alert">
+            {errors.name}
+          </span>
+        )}
       </div>
       <div className="form-group">
         <label htmlFor="email">Email</label>
-        <input type="email" id="email" name="email" value={form.email} onChange={handleChange} />
-        {errors.email && <span id="email-error" className="error-message">{errors.email}</span>}
+        <input
+          type="email"
+          id="email"
+          name="email"
+          value={form.email}
+          onChange={handleChange}
+          aria-invalid={!!errors.email}
+          aria-describedby={errors.email ? 'email-error' : undefined}
+          required
+        />
+        {errors.email && (
+          <span id="email-error" className="error-message" role="alert">
+            {errors.email}
+          </span>
+        )}
       </div>
       <div className="form-group">
         <label htmlFor="message">Message</label>
-        <textarea id="message" name="message" value={form.message} onChange={handleChange}></textarea>
-        {errors.message && <span id="message-error" className="error-message">{errors.message}</span>}
+        <textarea
+          id="message"
+          name="message"
+          value={form.message}
+          onChange={handleChange}
+          aria-invalid={!!errors.message}
+          aria-describedby={errors.message ? 'message-error' : undefined}
+          required
+        ></textarea>
+        {errors.message && (
+          <span id="message-error" className="error-message" role="alert">
+            {errors.message}
+          </span>
+        )}
       </div>
-      <button type="submit">Send</button>
-      {success && <span className="success-message">{success}</span>}
-      {submitError && <span className="error-message">{submitError}</span>}
+      <button type="submit" aria-label="Send message">Send</button>
+      {success && (
+        <span className="success-message" role="status" aria-live="polite">
+          {success}
+        </span>
+      )}
+      {submitError && (
+        <span className="error-message" role="alert">
+          {submitError}
+        </span>
+      )}
     </form>
   );
 }

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -9,7 +9,13 @@ export default function Hero() {
       <div className="hero-content container">
         <h1 className="heading-font">Handcrafted Bookbinding</h1>
         <p>Precision Bookbinding &amp; Finishing</p>
-        <button className="btn btn-primary" onClick={scrollToQuote}>Request a Quote</button>
+        <button
+          className="btn btn-primary"
+          onClick={scrollToQuote}
+          aria-label="Request a Quote"
+        >
+          Request a Quote
+        </button>
       </div>
     </section>
   );

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -19,7 +19,10 @@ export default function Navbar() {
         />
       </Link>
       <nav>
-        <ul className={open ? 'nav-links open' : 'nav-links'}>
+        <ul
+          id="nav-links"
+          className={open ? 'nav-links open' : 'nav-links'}
+        >
           <li><Link href="/" onClick={close}>Home</Link></li>
           <li><Link href="/services" onClick={close}>Services</Link></li>
           <li><Link href="/portfolio" onClick={close}>Portfolio</Link></li>

--- a/components/QuoteForm.tsx
+++ b/components/QuoteForm.tsx
@@ -67,36 +67,96 @@ export default function QuoteForm() {
         <form className="quote-form" onSubmit={handleSubmit} noValidate>
           <div className="form-group">
             <label htmlFor="quote-name">Name</label>
-            <input type="text" id="quote-name" name="name" value={form.name} onChange={handleChange} />
-            {errors.name && <span className="error-message">{errors.name}</span>}
+            <input
+              type="text"
+              id="quote-name"
+              name="name"
+              value={form.name}
+              onChange={handleChange}
+              aria-invalid={!!errors.name}
+              aria-describedby={errors.name ? 'quote-name-error' : undefined}
+              required
+            />
+            {errors.name && (
+              <span id="quote-name-error" className="error-message" role="alert">
+                {errors.name}
+              </span>
+            )}
           </div>
           <div className="form-group">
             <label htmlFor="quote-email">Email</label>
-            <input type="email" id="quote-email" name="email" value={form.email} onChange={handleChange} />
-            {errors.email && <span className="error-message">{errors.email}</span>}
+            <input
+              type="email"
+              id="quote-email"
+              name="email"
+              value={form.email}
+              onChange={handleChange}
+              aria-invalid={!!errors.email}
+              aria-describedby={errors.email ? 'quote-email-error' : undefined}
+              required
+            />
+            {errors.email && (
+              <span id="quote-email-error" className="error-message" role="alert">
+                {errors.email}
+              </span>
+            )}
           </div>
           <div className="form-group">
             <label htmlFor="book-type">Book Type</label>
-            <select id="book-type" name="bookType" value={form.bookType} onChange={handleChange}>
+            <select
+              id="book-type"
+              name="bookType"
+              value={form.bookType}
+              onChange={handleChange}
+              aria-invalid={!!errors.bookType}
+              aria-describedby={errors.bookType ? 'book-type-error' : undefined}
+              required
+            >
               <option value="">Select a type</option>
               <option value="hardcover">Hardcover</option>
               <option value="paperback">Paperback</option>
               <option value="leather">Leather</option>
             </select>
-            {errors.bookType && <span className="error-message">{errors.bookType}</span>}
+            {errors.bookType && (
+              <span id="book-type-error" className="error-message" role="alert">
+                {errors.bookType}
+              </span>
+            )}
           </div>
           <div className="form-group">
             <label htmlFor="quantity">Quantity</label>
-            <input type="number" id="quantity" name="quantity" min="1" value={form.quantity} onChange={handleChange} />
-            {errors.quantity && <span className="error-message">{errors.quantity}</span>}
+            <input
+              type="number"
+              id="quantity"
+              name="quantity"
+              min="1"
+              value={form.quantity}
+              onChange={handleChange}
+              aria-invalid={!!errors.quantity}
+              aria-describedby={errors.quantity ? 'quantity-error' : undefined}
+              required
+            />
+            {errors.quantity && (
+              <span id="quantity-error" className="error-message" role="alert">
+                {errors.quantity}
+              </span>
+            )}
           </div>
           <div className="form-group">
             <label htmlFor="quote-notes">Notes</label>
             <textarea id="quote-notes" name="notes" value={form.notes} onChange={handleChange}></textarea>
           </div>
-          <button type="submit">Submit</button>
-          {success && <span className="success-message">{success}</span>}
-          {submitError && <span className="error-message">{submitError}</span>}
+          <button type="submit" aria-label="Submit quote request">Submit</button>
+          {success && (
+            <span className="success-message" role="status" aria-live="polite">
+              {success}
+            </span>
+          )}
+          {submitError && (
+            <span className="error-message" role="alert">
+              {submitError}
+            </span>
+          )}
         </form>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add ARIA attributes for form validation and navigation
- label all buttons and links for screen readers
- document accessibility guidelines

## Testing
- `npm test`
- `npx @axe-core/cli http://localhost:3000 --exit 0 --chrome-options="--no-sandbox --disable-dev-shm-usage --user-data-dir=/tmp/axe"` *(fails: SessionNotCreatedError: user data directory is already in use)*

------
https://chatgpt.com/codex/tasks/task_b_68a7228b7de4832e93e34fb3721c96be