### PR TITLE
Refactor component styles into CSS modules

### DIFF
--- a/components/About.module.css
+++ b/components/About.module.css
@@ -1,0 +1,8 @@
+.about {
+  margin-top: 2em;
+}
+
+.text {
+  max-width: 800px;
+  margin: 0.5em auto 0;
+}

--- a/components/About.tsx
+++ b/components/About.tsx
@@ -1,8 +1,10 @@
+import styles from './About.module.css';
+
 export default function About() {
   return (
-    <section id="about" className="about container">
+    <section id="about" className={`${styles.about} container`}>
       <h2 className="heading-font">About Us</h2>
-      <p>Pioneering the market, Fouad Baayno opened his first shop in 1964 and launched the first bookbinding factory in 1972.</p>
+      <p className={styles.text}>Pioneering the market, Fouad Baayno opened his first shop in 1964 and launched the first bookbinding factory in 1972.</p>
     </section>
   );
 }

--- a/components/Blog.module.css
+++ b/components/Blog.module.css
@@ -1,0 +1,6 @@
+.blogGrid {
+  margin-top: 2em;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+}

--- a/components/Blog.tsx
+++ b/components/Blog.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import Image from 'next/image';
+import styles from './Blog.module.css';
 
 interface Post {
   slug: string;
@@ -16,7 +17,7 @@ export default function Blog({ posts = [] }: BlogProps) {
   return (
     <section id="blog" className="blog container">
       <h2 className="heading-font">Blog</h2>
-      <div className="blog-grid">
+      <div className={styles.blogGrid}>
         {posts.map((post) => (
           <article key={post.slug} className="card">
             {post.image && (

--- a/components/ContactForm.module.css
+++ b/components/ContactForm.module.css
@@ -1,0 +1,4 @@
+.contactForm {
+  max-width: 500px;
+  margin: 0 auto;
+}

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import styles from './ContactForm.module.css';
 
 interface FormState {
   name: string;
@@ -55,7 +56,7 @@ export default function ContactForm() {
   };
 
   return (
-    <form id="contact-form" className="contact-form" onSubmit={handleSubmit} noValidate>
+    <form id="contact-form" className={styles.contactForm} onSubmit={handleSubmit} noValidate>
       <div className="form-group">
         <label htmlFor="name">Name</label>
         <input type="text" id="name" name="name" value={form.name} onChange={handleChange} />
@@ -71,7 +72,7 @@ export default function ContactForm() {
         <textarea id="message" name="message" value={form.message} onChange={handleChange}></textarea>
         {errors.message && <span id="message-error" className="error-message">{errors.message}</span>}
       </div>
-      <button type="submit">Send</button>
+      <button type="submit" className="btn btn-primary">Send</button>
       {success && <span className="success-message">{success}</span>}
       {submitError && <span className="error-message">{submitError}</span>}
     </form>

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -60,21 +60,41 @@ export default function ContactForm() {
       <div className="form-group">
         <label htmlFor="name">Name</label>
         <input type="text" id="name" name="name" value={form.name} onChange={handleChange} />
-        {errors.name && <span id="name-error" className="error-message">{errors.name}</span>}
+        {errors.name && (
+          <span id="name-error" role="alert" className="error-message">
+            {errors.name}
+          </span>
+        )}
       </div>
       <div className="form-group">
         <label htmlFor="email">Email</label>
         <input type="email" id="email" name="email" value={form.email} onChange={handleChange} />
-        {errors.email && <span id="email-error" className="error-message">{errors.email}</span>}
+        {errors.email && (
+          <span id="email-error" role="alert" className="error-message">
+            {errors.email}
+          </span>
+        )}
       </div>
       <div className="form-group">
         <label htmlFor="message">Message</label>
         <textarea id="message" name="message" value={form.message} onChange={handleChange}></textarea>
-        {errors.message && <span id="message-error" className="error-message">{errors.message}</span>}
+        {errors.message && (
+          <span id="message-error" role="alert" className="error-message">
+            {errors.message}
+          </span>
+        )}
       </div>
       <button type="submit" className="btn btn-primary">Send</button>
-      {success && <span className="success-message">{success}</span>}
-      {submitError && <span className="error-message">{submitError}</span>}
+      {success && (
+        <span className="success-message" role="status" aria-live="polite">
+          {success}
+        </span>
+      )}
+      {submitError && (
+        <span className="error-message" role="alert" aria-live="polite">
+          {submitError}
+        </span>
+      )}
     </form>
   );
 }

--- a/components/Hero.module.css
+++ b/components/Hero.module.css
@@ -1,0 +1,72 @@
+.hero {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: var(--color-white);
+  height: 100vh;
+  background: url('https://images.unsplash.com/photo-1519682337058-a94d519337bc?auto=format&fit=crop&w=2400&q=80') center/cover no-repeat;
+}
+
+.hero::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  height: 100%;
+  padding: 2rem;
+}
+
+.hero h1 {
+  font-size: 3rem;
+}
+
+.hero p {
+  font-size: 1.5rem;
+}
+
+@media (max-width: 600px) {
+  .content {
+    padding: 1.5rem;
+  }
+  .hero h1 {
+    font-size: 2rem;
+  }
+  .hero p {
+    font-size: 1rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .hero h1 {
+    font-size: 4rem;
+  }
+  .hero p {
+    font-size: 2rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .hero h1 {
+    font-size: 5rem;
+  }
+  .hero p {
+    font-size: 2.5rem;
+  }
+}

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,3 +1,5 @@
+import styles from './Hero.module.css';
+
 export default function Hero() {
   const scrollToQuote = (): void => {
     if (typeof document !== 'undefined') {
@@ -5,8 +7,8 @@ export default function Hero() {
     }
   };
   return (
-    <section className="hero" id="hero">
-      <div className="hero-content container">
+    <section className={styles.hero} id="hero">
+      <div className={`${styles.content} container`}>
         <h1 className="heading-font">Handcrafted Bookbinding</h1>
         <p>Precision Bookbinding &amp; Finishing</p>
         <button className="btn btn-primary" onClick={scrollToQuote}>Request a Quote</button>

--- a/components/Layout.module.css
+++ b/components/Layout.module.css
@@ -1,0 +1,7 @@
+.stickyHeader {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background: var(--color-black);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,5 +1,6 @@
 import { useEffect, ReactNode } from 'react';
 import Navbar from './Navbar';
+import styles from './Layout.module.css';
 
 interface LayoutProps {
   children: ReactNode;
@@ -30,7 +31,7 @@ export default function Layout({ children }: LayoutProps) {
 
   return (
     <>
-      <div className="sticky-header">
+      <div className={styles.stickyHeader}>
         <Navbar />
       </div>
       {children}

--- a/components/Navbar.module.css
+++ b/components/Navbar.module.css
@@ -1,0 +1,76 @@
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--color-black);
+  color: var(--color-white);
+  padding: 1em;
+  flex-wrap: wrap;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  margin-right: 1em;
+}
+
+.logo img {
+  height: 40px;
+  width: auto;
+  display: block;
+}
+
+.navLinks {
+  list-style: none;
+  display: flex;
+  gap: 1em;
+  margin: 0;
+  padding: 0;
+  align-items: center;
+}
+
+.navLinks a {
+  color: var(--color-white);
+  text-decoration: none;
+  padding-bottom: 2px;
+  border-bottom: 2px solid transparent;
+  transition: color 0.3s, border-color 0.3s;
+}
+
+.navLinks a:hover,
+.navLinks a:focus {
+  color: var(--color-accent);
+}
+
+.navLinks a.active {
+  color: var(--color-accent);
+  border-color: var(--color-gold);
+}
+
+.navToggle {
+  display: none;
+  background: none;
+  border: none;
+  color: var(--color-white);
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0.25em 0.5em;
+}
+
+@media (max-width: 768px) {
+  .navToggle {
+    display: block;
+  }
+
+  .navLinks {
+    display: none;
+    flex-direction: column;
+    width: 100%;
+    background: var(--color-black);
+    margin-top: 1em;
+  }
+
+  .open {
+    display: flex;
+  }
+}

--- a/components/Navbar.module.css
+++ b/components/Navbar.module.css
@@ -42,7 +42,7 @@
   color: var(--color-accent);
 }
 
-.navLinks a.active {
+.active {
   color: var(--color-accent);
   border-color: var(--color-gold);
 }

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -9,6 +9,7 @@ export default function Navbar() {
   const toggle = (): void => setOpen(!open);
   const close = (): void => setOpen(false);
   const router = useRouter();
+  const isActive = (path: string): boolean => router.pathname === path;
   return (
     <header className={styles.navbar}>
       <Link href="/" className={styles.logo} onClick={close}>
@@ -21,11 +22,31 @@ export default function Navbar() {
       </Link>
       <nav>
         <ul id="nav-links" className={`${styles.navLinks} ${open ? styles.open : ''}`}>
-          <li><Link href="/" onClick={close}>Home</Link></li>
-          <li><Link href="/services" onClick={close}>Services</Link></li>
-          <li><Link href="/portfolio" onClick={close}>Portfolio</Link></li>
-          <li><Link href="/blog" onClick={close}>Blog</Link></li>
-          <li><Link href="/contact" onClick={close}>Contact</Link></li>
+          <li>
+            <Link href="/" className={isActive('/') ? styles.active : undefined} onClick={close}>
+              Home
+            </Link>
+          </li>
+          <li>
+            <Link href="/services" className={isActive('/services') ? styles.active : undefined} onClick={close}>
+              Services
+            </Link>
+          </li>
+          <li>
+            <Link href="/portfolio" className={isActive('/portfolio') ? styles.active : undefined} onClick={close}>
+              Portfolio
+            </Link>
+          </li>
+          <li>
+            <Link href="/blog" className={isActive('/blog') ? styles.active : undefined} onClick={close}>
+              Blog
+            </Link>
+          </li>
+          <li>
+            <Link href="/contact" className={isActive('/contact') ? styles.active : undefined} onClick={close}>
+              Contact
+            </Link>
+          </li>
         </ul>
       </nav>
       <button className={styles.navToggle} aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded={open} onClick={toggle}>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { useState } from 'react';
 import { useRouter } from 'next/router';
 import Image from 'next/image';
+import styles from './Navbar.module.css';
 
 export default function Navbar() {
   const [open, setOpen] = useState<boolean>(false);
@@ -9,8 +10,8 @@ export default function Navbar() {
   const close = (): void => setOpen(false);
   const router = useRouter();
   return (
-    <header className="navbar">
-      <Link href="/" className="logo" onClick={close}>
+    <header className={styles.navbar}>
+      <Link href="/" className={styles.logo} onClick={close}>
         <Image
           src={`${router.basePath}/logo.svg`}
           alt="Fouad Baayno Bookbindery logo"
@@ -19,7 +20,7 @@ export default function Navbar() {
         />
       </Link>
       <nav>
-        <ul className={open ? 'nav-links open' : 'nav-links'}>
+        <ul id="nav-links" className={`${styles.navLinks} ${open ? styles.open : ''}`}>
           <li><Link href="/" onClick={close}>Home</Link></li>
           <li><Link href="/services" onClick={close}>Services</Link></li>
           <li><Link href="/portfolio" onClick={close}>Portfolio</Link></li>
@@ -27,7 +28,7 @@ export default function Navbar() {
           <li><Link href="/contact" onClick={close}>Contact</Link></li>
         </ul>
       </nav>
-      <button id="nav-toggle" aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded={open} onClick={toggle}>
+      <button className={styles.navToggle} aria-label="Toggle navigation" aria-controls="nav-links" aria-expanded={open} onClick={toggle}>
         &#9776;
       </button>
     </header>

--- a/components/Portfolio.module.css
+++ b/components/Portfolio.module.css
@@ -1,0 +1,6 @@
+.portfolioGrid {
+  margin-top: 2em;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+}

--- a/components/Portfolio.tsx
+++ b/components/Portfolio.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import styles from './Portfolio.module.css';
 
 interface PortfolioItem {
   img: string;
@@ -28,7 +29,7 @@ export default function Portfolio() {
   return (
     <section id="portfolio" className="portfolio container">
       <h2 className="heading-font">Portfolio</h2>
-      <div className="portfolio-grid">
+      <div className={styles.portfolioGrid}>
         {portfolioData.map((item, idx) => (
           <article key={idx} className="card">
             <Image

--- a/components/QuoteForm.module.css
+++ b/components/QuoteForm.module.css
@@ -1,0 +1,8 @@
+.quote {
+  margin-top: 2em;
+}
+
+.quoteForm {
+  max-width: 500px;
+  margin: 0 auto;
+}

--- a/components/QuoteForm.tsx
+++ b/components/QuoteForm.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import styles from './QuoteForm.module.css';
 
 interface QuoteFormState {
   name: string;
@@ -61,10 +62,10 @@ export default function QuoteForm() {
   };
 
   return (
-    <section id="quote" className="quote">
+    <section id="quote" className={styles.quote}>
       <div className="container">
         <h2 className="heading-font">Request a Quote</h2>
-        <form className="quote-form" onSubmit={handleSubmit} noValidate>
+        <form className={styles.quoteForm} onSubmit={handleSubmit} noValidate>
           <div className="form-group">
             <label htmlFor="quote-name">Name</label>
             <input type="text" id="quote-name" name="name" value={form.name} onChange={handleChange} />
@@ -94,7 +95,7 @@ export default function QuoteForm() {
             <label htmlFor="quote-notes">Notes</label>
             <textarea id="quote-notes" name="notes" value={form.notes} onChange={handleChange}></textarea>
           </div>
-          <button type="submit">Submit</button>
+          <button type="submit" className="btn btn-primary">Submit</button>
           {success && <span className="success-message">{success}</span>}
           {submitError && <span className="error-message">{submitError}</span>}
         </form>

--- a/components/QuoteForm.tsx
+++ b/components/QuoteForm.tsx
@@ -69,12 +69,20 @@ export default function QuoteForm() {
           <div className="form-group">
             <label htmlFor="quote-name">Name</label>
             <input type="text" id="quote-name" name="name" value={form.name} onChange={handleChange} />
-            {errors.name && <span className="error-message">{errors.name}</span>}
+            {errors.name && (
+              <span className="error-message" role="alert">
+                {errors.name}
+              </span>
+            )}
           </div>
           <div className="form-group">
             <label htmlFor="quote-email">Email</label>
             <input type="email" id="quote-email" name="email" value={form.email} onChange={handleChange} />
-            {errors.email && <span className="error-message">{errors.email}</span>}
+            {errors.email && (
+              <span className="error-message" role="alert">
+                {errors.email}
+              </span>
+            )}
           </div>
           <div className="form-group">
             <label htmlFor="book-type">Book Type</label>
@@ -84,20 +92,36 @@ export default function QuoteForm() {
               <option value="paperback">Paperback</option>
               <option value="leather">Leather</option>
             </select>
-            {errors.bookType && <span className="error-message">{errors.bookType}</span>}
+            {errors.bookType && (
+              <span className="error-message" role="alert">
+                {errors.bookType}
+              </span>
+            )}
           </div>
           <div className="form-group">
             <label htmlFor="quantity">Quantity</label>
             <input type="number" id="quantity" name="quantity" min="1" value={form.quantity} onChange={handleChange} />
-            {errors.quantity && <span className="error-message">{errors.quantity}</span>}
+            {errors.quantity && (
+              <span className="error-message" role="alert">
+                {errors.quantity}
+              </span>
+            )}
           </div>
           <div className="form-group">
             <label htmlFor="quote-notes">Notes</label>
             <textarea id="quote-notes" name="notes" value={form.notes} onChange={handleChange}></textarea>
           </div>
           <button type="submit" className="btn btn-primary">Submit</button>
-          {success && <span className="success-message">{success}</span>}
-          {submitError && <span className="error-message">{submitError}</span>}
+          {success && (
+            <span className="success-message" role="status" aria-live="polite">
+              {success}
+            </span>
+          )}
+          {submitError && (
+            <span className="error-message" role="alert" aria-live="polite">
+              {submitError}
+            </span>
+          )}
         </form>
       </div>
     </section>

--- a/components/Services.module.css
+++ b/components/Services.module.css
@@ -1,0 +1,6 @@
+.serviceGrid {
+  margin-top: 2em;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+}

--- a/components/Services.tsx
+++ b/components/Services.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import styles from './Services.module.css';
 
 interface Service {
   icon?: string;
@@ -17,9 +18,9 @@ export default function Services() {
   }, []);
 
   return (
-    <section id="services" className="services container">
+    <section id="services" className="container">
       <h2 className="heading-font">Services</h2>
-      <div className="service-grid">
+      <div className={styles.serviceGrid}>
         {services.map((service, idx) => (
           <article key={idx} className="card">
             {service.icon && <div className="icon">{service.icon}</div>}

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,1 @@
+declare module '*.module.css';

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,1 +1,4 @@
-declare module '*.module.css';
+declare module '*.module.css' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}

--- a/pages/Contact.module.css
+++ b/pages/Contact.module.css
@@ -1,0 +1,7 @@
+.contact {
+  margin-top: 2em;
+}
+
+.companyDetails {
+  margin-bottom: 1.5em;
+}

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import Layout from '@/components/Layout';
 import ContactForm from '@/components/ContactForm';
 import SEO from '@/components/SEO';
+import styles from './Contact.module.css';
 
 interface CompanyInfo {
   address: string;
@@ -21,10 +22,10 @@ export default function ContactPage() {
   return (
     <Layout>
       <SEO title="Contact - Baayno" canonical="https://www.baayno.com/contact" />
-      <section id="contact" className="contact">
+      <section id="contact" className={styles.contact}>
         <div className="container">
           <h2 className="heading-font">Contact Us</h2>
-          <div className="company-details">
+          <div className={styles.companyDetails}>
             <p>{info.address}</p>
             <p>
               {info.phones.map((phone, idx) => (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -154,10 +154,6 @@ h6 {
   margin-top: 0;
 }
 
-.contact {
-  margin-top: 2em;
-}
-
 .form-group {
   margin-bottom: 1em;
   text-align: left;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -22,6 +22,8 @@ body {
   font-family: Arial, Helvetica, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  margin: 0;
+  padding: 0;
 }
 
 * {
@@ -40,535 +42,168 @@ a {
     color-scheme: dark;
   }
 }
+
 /* Font declarations */
 @font-face {
-    font-family: 'Open Sans';
-    font-style: normal;
-    font-weight: 400;
-    src: url('https://fonts.gstatic.com/s/opensans/v34/mem8YaGs126MiZpBA-UFVZ0e.woff2') format('woff2');
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: url('https://fonts.gstatic.com/s/opensans/v34/mem8YaGs126MiZpBA-UFVZ0e.woff2') format('woff2');
 }
 @font-face {
-    font-family: 'Open Sans';
-    font-style: normal;
-    font-weight: 700;
-    src: url('https://fonts.gstatic.com/s/opensans/v34/mem5YaGs126MiZpBA-UN7rgOXOhp.woff2') format('woff2');
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: url('https://fonts.gstatic.com/s/opensans/v34/mem5YaGs126MiZpBA-UN7rgOXOhp.woff2') format('woff2');
 }
 @font-face {
-    font-family: 'caecilia_lt_std55_roman';
-    font-style: normal;
-    font-weight: 700;
-    src: url('https://fonts.cdnfonts.com/s/13982/CaeciliaLTStd-BoldItalic.woff') format('woff');
+  font-family: 'caecilia_lt_std55_roman';
+  font-style: normal;
+  font-weight: 700;
+  src: url('https://fonts.cdnfonts.com/s/13982/CaeciliaLTStd-BoldItalic.woff') format('woff');
 }
 
 :root {
-    --color-black: #0b0b0b;
-    --color-white: #ffffff;
-    --color-accent: #d61f26;
-    --color-accent-dark: #a3181e;
-    --color-gold: #c9a227;
-    --font-body: 'Open Sans', sans-serif;
-    --font-heading: 'caecilia_lt_std55_roman', serif;
-    --fw-normal: 400;
-    --fw-bold: 700;
-    --radius: 12px;
-    --btn-padding: 0.75em 1.5em;
+  --color-black: #0b0b0b;
+  --color-white: #ffffff;
+  --color-accent: #d61f26;
+  --color-accent-dark: #a3181e;
+  --color-gold: #c9a227;
+  --font-body: 'Open Sans', sans-serif;
+  --font-heading: 'caecilia_lt_std55_roman', serif;
+  --fw-normal: 400;
+  --fw-bold: 700;
+  --radius: 12px;
+  --btn-padding: 0.75em 1.5em;
 }
 
 .body-font {
-    font-family: var(--font-body);
-    font-weight: var(--fw-normal);
+  font-family: var(--font-body);
+  font-weight: var(--fw-normal);
 }
 
 .heading-font {
-    font-family: var(--font-heading);
-    font-weight: var(--fw-bold);
+  font-family: var(--font-heading);
+  font-weight: var(--fw-bold);
 }
 
-h1, h2, h3, h4, h5, h6 {
-    font-family: var(--font-heading);
-    font-weight: var(--fw-bold);
-}
-
-body {
-    margin: 0;
-    padding: 0;
-    background: var(--color-white);
-    color: var(--color-black);
-    font-family: var(--font-body);
-    font-weight: var(--fw-normal);
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-heading);
+  font-weight: var(--fw-bold);
 }
 
 .container {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 1em;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1em;
 }
 
-.sticky-header {
-    position: sticky;
-    top: 0;
-    z-index: 1000;
-    background: var(--color-black);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+.btn {
+  display: inline-block;
+  padding: var(--btn-padding);
+  border-radius: var(--radius);
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: background 0.3s, color 0.3s, transform 0.3s;
 }
 
-
-.navbar {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    background: var(--color-black);
-    color: var(--color-white);
-    padding: 1em;
-    flex-wrap: wrap;
+.btn-primary {
+  background: var(--color-accent);
+  color: var(--color-white);
 }
 
-.logo {
-    display: flex;
-    align-items: center;
-    margin-right: 1em;
-}
-
-.logo img {
-    height: 40px;
-    width: auto;
-    display: block;
-}
-
-.nav-links {
-    list-style: none;
-    display: flex;
-    gap: 1em;
-    margin: 0;
-    padding: 0;
-    align-items: center;
-}
-
-.nav-links a {
-    color: var(--color-white);
-    text-decoration: none;
-    padding-bottom: 2px;
-    border-bottom: 2px solid transparent;
-    transition: color 0.3s, border-color 0.3s;
-}
-
-.nav-links a:hover,
-.nav-links a:focus {
-    color: var(--color-accent);
-}
-
-.nav-links a.active {
-    color: var(--color-accent);
-    border-color: var(--color-gold);
-}
-
-#nav-toggle {
-    display: none;
-    background: none;
-    border: none;
-    color: var(--color-white);
-    font-size: 1.5rem;
-    cursor: pointer;
-    padding: 0.25em 0.5em;
-}
-
-
-.hero {
-    position: relative;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    color: var(--color-white);
-    height: 100vh;
-    background: url('https://images.unsplash.com/photo-1519682337058-a94d519337bc?auto=format&fit=crop&w=2400&q=80') center/cover no-repeat;
-}
-
-.hero .container {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    text-align: center;
-    height: 100%;
-    padding: 2rem;
-}
-
-.hero::before {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.5);
-}
-
-.hero > * {
-    position: relative;
-    z-index: 1;
-}
-
-.hero h1 {
-    font-size: 3rem;
-}
-
-.hero p {
-    font-size: 1.5rem;
-}
-
-@media (max-width: 600px) {
-    .hero .container {
-        padding: 1.5rem;
-    }
-    .hero h1 {
-        font-size: 2rem;
-    }
-
-    .hero p {
-        font-size: 1rem;
-    }
-}
-header {
-}
-
-main {
-    padding: 2em;
-    text-align: center;
-}
-
-.about {
-    margin-top: 2em;
-}
-
-.about p {
-    max-width: 800px;
-    margin: 0.5em auto 0;
-}
-
-.services,
-.portfolio-grid,
-.blog-grid {
-    margin-top: 2em;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 1.5rem;
+.btn-primary:hover,
+.btn-primary:focus {
+  background: var(--color-accent-dark);
+  transform: translateY(-2px);
 }
 
 .card {
-    background: var(--color-white);
-    padding: 1em;
-    border-radius: var(--radius);
-    border-top: 4px solid var(--color-accent);
-    box-shadow: var(--shadow, 0 2px 4px rgba(0, 0, 0, 0.1));
-    transition: all 0.3s ease;
+  background: var(--color-white);
+  padding: 1em;
+  border-radius: var(--radius);
+  border-top: 4px solid var(--color-accent);
+  box-shadow: var(--shadow, 0 2px 4px rgba(0, 0, 0, 0.1));
+  transition: all 0.3s ease;
 }
 
 .card img {
-    width: 100%;
-    height: auto;
-    border-radius: var(--radius);
-    margin-bottom: 0.5rem;
+  width: 100%;
+  height: auto;
+  border-radius: var(--radius);
+  margin-bottom: 0.5rem;
 }
 
 .card .icon {
-    font-size: 2rem;
-    margin-bottom: 0.5rem;
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
 }
 
 .card:hover,
 .card:focus-within {
-    transform: translateY(-5px);
-    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+  transform: translateY(-5px);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
 }
 
 .card h3 {
-    margin-top: 0;
+  margin-top: 0;
 }
 
 .contact {
-    margin-top: 2em;
-}
-
-.quote {
-    margin-top: 2em;
-}
-
-.faqs {
-    margin-top: 2em;
-}
-
-.contact-form,
-.quote-form {
-    max-width: 500px;
-    margin: 0 auto;
+  margin-top: 2em;
 }
 
 .form-group {
-    margin-bottom: 1em;
-    text-align: left;
-}
-
-.faq {
-    margin-bottom: 1em;
-}
-
-.faq h3 {
-    margin-bottom: 0.5em;
+  margin-bottom: 1em;
+  text-align: left;
 }
 
 .form-group label {
-    display: block;
-    margin-bottom: 0.5em;
+  display: block;
+  margin-bottom: 0.5em;
 }
 
 .form-group input,
 .form-group textarea,
 .form-group select {
-    width: 100%;
-    padding: 0.5em;
-    border: 1px solid var(--color-black);
-    border-radius: 4px;
-    font-family: inherit;
+  width: 100%;
+  padding: 0.5em;
+  border: 1px solid var(--color-black);
+  border-radius: 4px;
+  font-family: inherit;
 }
 
 .form-group textarea {
-    resize: vertical;
-    min-height: 120px;
+  resize: vertical;
+  min-height: 120px;
 }
 
 .error-message {
-    display: block;
-    color: var(--color-accent);
-    font-size: 0.875em;
-    margin-top: 0.25em;
+  display: block;
+  color: var(--color-accent);
+  font-size: 0.875em;
+  margin-top: 0.25em;
 }
 
 .success-message {
-    color: var(--color-accent);
-    margin-top: 1em;
-    display: block;
-}
-
-.quote-form button[type="submit"] {
-    background: var(--color-accent);
-    color: var(--color-white);
-}
-
-.testimonials {
-    margin-top: 2em;
-}
-
-.testimonial-carousel {
-    position: relative;
-    max-width: 500px;
-    margin: 0 auto;
-    min-height: 180px;
-}
-
-.testimonial {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    padding: 1em;
-    background: var(--color-white);
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    opacity: 0;
-    transition: opacity 0.5s ease;
-}
-
-.testimonial.active {
-    position: relative;
-    opacity: 1;
-}
-
-.carousel-btn {
-    position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    background: rgba(0, 0, 0, 0.5);
-    color: var(--color-white);
-    border: none;
-    border-radius: 50%;
-    width: 30px;
-    height: 30px;
-    cursor: pointer;
-}
-
-.carousel-btn.prev {
-    left: 10px;
-}
-
-.carousel-btn.next {
-    right: 10px;
-}
-button {
-    padding: var(--btn-padding);
-    font-size: 1em;
-    background: var(--color-accent);
-    color: var(--color-white);
-    border: none;
-    border-radius: var(--radius);
-    cursor: pointer;
-    transition: all 0.3s ease;
-}
-
-.btn {
-    display: inline-block;
-    padding: var(--btn-padding);
-    border-radius: var(--radius);
-    border: 2px solid transparent;
-    cursor: pointer;
-    transition: background 0.3s, color 0.3s, transform 0.3s;
-}
-
-.btn-primary {
-    background: var(--color-accent);
-    color: var(--color-white);
-}
-
-.btn-primary:hover,
-.btn-primary:focus {
-    background: var(--color-accent-dark);
-    transform: translateY(-2px);
-}
-
-button:hover,
-button:focus {
-    background: var(--color-accent-dark);
-    transform: translateY(-2px);
-}
-footer {
-    text-align: center;
-    padding: 1em;
-    background: var(--color-black);
-    color: var(--color-white);
-    position: fixed;
-    width: 100%;
-    bottom: 0;
-}
-
-.gallery-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-    gap: 1em;
-}
-
-.gallery-grid figure {
-    margin: 0;
-}
-
-.gallery-grid img {
-    width: 100%;
-    display: block;
-    border-radius: var(--radius);
-    cursor: pointer;
-}
-
-.lightbox {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.8);
-    display: none;
-    justify-content: center;
-    align-items: center;
-    flex-direction: column;
-    z-index: 1000;
-}
-
-.lightbox.open {
-    display: flex;
-}
-
-.lightbox img {
-    max-width: 90%;
-    max-height: 80%;
-    border-radius: var(--radius);
-}
-
-.lightbox-close {
-    color: var(--color-white);
-    font-size: 2rem;
-    position: absolute;
-    top: 1rem;
-    right: 1rem;
-    cursor: pointer;
-}
-
-.lightbox-caption {
-    color: var(--color-white);
-    margin-top: 0.5em;
-}
-
-@media (max-width: 768px) {
-    #nav-toggle {
-        display: block;
-    }
-
-    .nav-links {
-        display: none;
-        flex-direction: column;
-        width: 100%;
-        background: var(--color-black);
-        margin-top: 1em;
-    }
-
-    .nav-links.open {
-        display: flex;
-    }
+  color: var(--color-accent);
+  margin-top: 1em;
+  display: block;
 }
 
 @media (min-width: 768px) {
-    .container {
-        padding: 0 2em;
-    }
-
-    .hero h1 {
-        font-size: 4rem;
-    }
-
-    .hero p {
-        font-size: 2rem;
-    }
-
-
-    .testimonial-carousel {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-        gap: 1.5em;
-        position: static;
-        max-width: none;
-        min-height: 0;
-    }
-
-    .testimonial {
-        position: relative;
-        opacity: 1;
-    }
-
-    .carousel-btn {
-        display: none;
-    }
+  .container {
+    padding: 0 2em;
+  }
 }
 
 @media (min-width: 1024px) {
-    .container {
-        max-width: 1400px;
-    }
-
-    .hero h1 {
-        font-size: 5rem;
-    }
-
-    .hero p {
-        font-size: 2.5rem;
-    }
-
-    .gallery-grid {
-        grid-template-columns: repeat(3, 1fr);
-    }
+  .container {
+    max-width: 1400px;
+  }
 }


### PR DESCRIPTION
## Summary
- migrate component styles to dedicated CSS modules
- streamline `globals.css` to only shared utilities and variables
- use button utility classes in forms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a723e43690832ea85213e6aea7fc75