### PR TITLE
refactor: centralize mailer configuration

### DIFF
--- a/lib/mailer.ts
+++ b/lib/mailer.ts
@@ -1,0 +1,61 @@
+import nodemailer from 'nodemailer';
+
+type EnvVars = {
+  SMTP_HOST: string;
+  SMTP_PORT: string;
+  SMTP_USER: string;
+  SMTP_PASS: string;
+  SMTP_FROM: string;
+  SMTP_TO: string;
+};
+
+let transporter: nodemailer.Transporter | null = null;
+
+function validateEnv(): EnvVars {
+  const {
+    SMTP_HOST,
+    SMTP_PORT,
+    SMTP_USER,
+    SMTP_PASS,
+    SMTP_FROM,
+    SMTP_TO,
+  } = process.env;
+
+  const missing = [
+    'SMTP_HOST',
+    'SMTP_PORT',
+    'SMTP_USER',
+    'SMTP_PASS',
+    'SMTP_FROM',
+    'SMTP_TO',
+  ].filter((key) => !process.env[key as keyof EnvVars]);
+
+  if (missing.length > 0) {
+    throw new Error(`Missing required env vars: ${missing.join(', ')}`);
+  }
+
+  return {
+    SMTP_HOST: SMTP_HOST!,
+    SMTP_PORT: SMTP_PORT!,
+    SMTP_USER: SMTP_USER!,
+    SMTP_PASS: SMTP_PASS!,
+    SMTP_FROM: SMTP_FROM!,
+    SMTP_TO: SMTP_TO!,
+  };
+}
+
+export default function getTransporter(): nodemailer.Transporter {
+  if (!transporter) {
+    const env = validateEnv();
+    transporter = nodemailer.createTransport({
+      host: env.SMTP_HOST,
+      port: parseInt(env.SMTP_PORT, 10) || 587,
+      secure: parseInt(env.SMTP_PORT, 10) === 465,
+      auth: {
+        user: env.SMTP_USER,
+        pass: env.SMTP_PASS,
+      },
+    });
+  }
+  return transporter;
+}

--- a/pages/api/contact.tsx
+++ b/pages/api/contact.tsx
@@ -1,15 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import nodemailer from 'nodemailer';
-
-const transporter = nodemailer.createTransport({
-  host: process.env.SMTP_HOST,
-  port: parseInt(process.env.SMTP_PORT ?? '0', 10) || 587,
-  secure: parseInt(process.env.SMTP_PORT ?? '0', 10) === 465,
-  auth: {
-    user: process.env.SMTP_USER,
-    pass: process.env.SMTP_PASS,
-  },
-});
+import getTransporter from '../../lib/mailer';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
   if (req.method !== 'POST') {
@@ -21,6 +11,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const { name, email, message } = req.body as { name: string; email: string; message: string };
 
   try {
+    const transporter = getTransporter();
     await transporter.sendMail({
       from: process.env.SMTP_FROM,
       to: process.env.SMTP_TO,

--- a/pages/api/quote.tsx
+++ b/pages/api/quote.tsx
@@ -1,15 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import nodemailer from 'nodemailer';
-
-const transporter = nodemailer.createTransport({
-  host: process.env.SMTP_HOST,
-  port: parseInt(process.env.SMTP_PORT ?? '0', 10) || 587,
-  secure: parseInt(process.env.SMTP_PORT ?? '0', 10) === 465,
-  auth: {
-    user: process.env.SMTP_USER,
-    pass: process.env.SMTP_PASS,
-  },
-});
+import getTransporter from '../../lib/mailer';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
   if (req.method !== 'POST') {
@@ -27,6 +17,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   };
 
   try {
+    const transporter = getTransporter();
     await transporter.sendMail({
       from: process.env.SMTP_FROM,
       to: process.env.SMTP_TO,


### PR DESCRIPTION
## Summary
- add shared mailer utility that validates required SMTP env vars and reuses a single nodemailer transporter
- replace duplicate transporter setup in contact and quote API routes with shared utility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a72e211768832e913ae2e8996288cb