### PR TITLE
feat: enhance navbar interactions

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -2,13 +2,14 @@ import Link from 'next/link';
 import { useState } from 'react';
 import { useRouter } from 'next/router';
 import Image from 'next/image';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
 
 export default function Navbar() {
   const [open, setOpen] = useState<boolean>(false);
   const toggle = (): void => setOpen(!open);
   const close = (): void => setOpen(false);
   const router = useRouter();
+  const isActive = (path: string): boolean => router.pathname === path;
   return (
     <header className="navbar">
       <Link href="/" className="logo" onClick={close}>
@@ -20,33 +21,33 @@ export default function Navbar() {
         />
       </Link>
       <nav>
-        <AnimatePresence>
-          {open && (
-            <motion.ul
-              id="nav-links"
-              className="nav-links open"
-              initial={{ x: '100%', opacity: 0 }}
-              animate={{ x: 0, opacity: 1, transition: { type: 'spring', stiffness: 300, damping: 30 } }}
-              exit={{ x: '100%', opacity: 0, transition: { type: 'spring', stiffness: 300, damping: 30 } }}
-            >
-              <motion.li initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.1 }}>
-                <Link href="/" onClick={close}>Home</Link>
-              </motion.li>
-              <motion.li initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.2 }}>
-                <Link href="/services" onClick={close}>Services</Link>
-              </motion.li>
-              <motion.li initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.3 }}>
-                <Link href="/portfolio" onClick={close}>Portfolio</Link>
-              </motion.li>
-              <motion.li initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.4 }}>
-                <Link href="/blog" onClick={close}>Blog</Link>
-              </motion.li>
-              <motion.li initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.5 }}>
-                <Link href="/contact" onClick={close}>Contact</Link>
-              </motion.li>
-            </motion.ul>
-          )}
-        </AnimatePresence>
+        <ul id="nav-links" className={`nav-links ${open ? 'open' : ''}`}>
+          <li>
+            <Link href="/" onClick={close} className={isActive('/') ? 'active' : ''}>
+              Home
+            </Link>
+          </li>
+          <li>
+            <Link href="/services" onClick={close} className={isActive('/services') ? 'active' : ''}>
+              Services
+            </Link>
+          </li>
+          <li>
+            <Link href="/portfolio" onClick={close} className={isActive('/portfolio') ? 'active' : ''}>
+              Portfolio
+            </Link>
+          </li>
+          <li>
+            <Link href="/blog" onClick={close} className={isActive('/blog') ? 'active' : ''}>
+              Blog
+            </Link>
+          </li>
+          <li>
+            <Link href="/contact" onClick={close} className={isActive('/contact') ? 'active' : ''}>
+              Contact
+            </Link>
+          </li>
+        </ul>
       </nav>
       <motion.button
         id="nav-toggle"
@@ -56,7 +57,37 @@ export default function Navbar() {
         onClick={toggle}
         whileTap={{ scale: 0.9 }}
       >
-        &#9776;
+        {open ? (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width="24"
+            height="24"
+            aria-hidden="true"
+          >
+            <path
+              d="M6 6L18 18M6 18L18 6"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+          </svg>
+        ) : (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width="24"
+            height="24"
+            aria-hidden="true"
+          >
+            <path
+              d="M4 6h16M4 12h16M4 18h16"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+          </svg>
+        )}
       </motion.button>
     </header>
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -135,6 +135,7 @@ body {
     display: block;
 }
 
+
 .nav-links {
     list-style: none;
     display: flex;
@@ -147,9 +148,29 @@ body {
 .nav-links a {
     color: var(--color-white);
     text-decoration: none;
-    padding-bottom: 2px;
-    border-bottom: 2px solid transparent;
-    transition: color 0.3s, border-color 0.3s;
+    position: relative;
+    transition: color 0.3s ease;
+}
+
+.nav-links a::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: -2px;
+    width: 100%;
+    height: 2px;
+    background: var(--color-accent);
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform 0.3s ease;
+}
+
+@media (min-width: 768px) {
+    .nav-links a:hover::after,
+    .nav-links a:focus::after,
+    .nav-links a.active::after {
+        transform: scaleX(1);
+    }
 }
 
 .nav-links a:hover,
@@ -159,7 +180,6 @@ body {
 
 .nav-links a.active {
     color: var(--color-accent);
-    border-color: var(--color-gold);
 }
 
 #nav-toggle {
@@ -510,15 +530,23 @@ footer {
     }
 
     .nav-links {
-        display: none;
         flex-direction: column;
         width: 100%;
         background: var(--color-black);
         margin-top: 1em;
+        max-height: 0;
+        overflow: hidden;
+        opacity: 0;
+        transform: translateY(-10px);
+        pointer-events: none;
+        transition: max-height 0.3s ease, opacity 0.3s ease, transform 0.3s ease;
     }
 
     .nav-links.open {
-        display: flex;
+        max-height: 500px;
+        opacity: 1;
+        transform: translateY(0);
+        pointer-events: auto;
     }
 }
 

--- a/tests/Navbar.test.tsx
+++ b/tests/Navbar.test.tsx
@@ -10,15 +10,16 @@ describe('Navbar', () => {
   it('toggles navigation menu when button is clicked', () => {
     const { container } = render(<Navbar />);
     const toggleButton = screen.getByRole('button', { name: /toggle navigation/i });
+    const navLinks = container.querySelector('#nav-links');
     expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
-    expect(container.querySelector('ul')).toBeNull();
+    expect(navLinks).not.toHaveClass('open');
     fireEvent.click(toggleButton);
     expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
-    expect(container.querySelector('ul')).toBeInTheDocument();
+    expect(navLinks).toHaveClass('open');
     fireEvent.click(toggleButton);
     expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
     return waitFor(() => {
-      expect(container.querySelector('ul')).toBeNull();
+      expect(navLinks).not.toHaveClass('open');
     });
   });
 });


### PR DESCRIPTION
## Summary
- use menu and close icons for mobile toggle
- animate nav links with CSS transitions and underline slide effects
- update navbar tests for persistent nav container

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a839907e8c832eb618604012f9c8ac