### PR TITLE
Process markdown asynchronously in getPostData

### DIFF
--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -38,6 +38,6 @@ export async function getPostData(slug: string): Promise<PostData> {
   const fullPath = path.join(postsDirectory, `${slug}.md`);
   const fileContents = await fs.readFile(fullPath, 'utf8');
   const { data, content } = matter(fileContents);
-  const htmlContent = marked(content);
+  const htmlContent = await marked(content);
   return { slug, content: htmlContent, ...(data as Omit<PostData, 'slug' | 'content'>) };
 }


### PR DESCRIPTION
## Summary
- Ensure `getPostData` converts markdown using the async `marked` API.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a848f7cc88832eaf7b76aced723efb