### PR TITLE
refactor: move component styles to modules

### DIFF
--- a/components/About.module.css
+++ b/components/About.module.css
@@ -1,0 +1,8 @@
+.about {
+  margin-top: 2em;
+}
+
+.about p {
+  max-width: 800px;
+  margin: 0.5em auto 0;
+}

--- a/components/About.tsx
+++ b/components/About.tsx
@@ -1,6 +1,8 @@
+import styles from './About.module.css';
+
 export default function About() {
   return (
-    <section id="about" className="about container">
+    <section id="about" className={`container ${styles.about}`}>
       <h2 className="heading-font">About Us</h2>
       <p>Pioneering the market, Fouad Baayno opened his first shop in 1964 and launched the first bookbinding factory in 1972.</p>
     </section>

--- a/components/Blog.module.css
+++ b/components/Blog.module.css
@@ -1,0 +1,10 @@
+.blog {
+  margin-top: 2em;
+}
+
+.blogGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2em;
+}

--- a/components/Blog.tsx
+++ b/components/Blog.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import type { PostMeta } from '@/lib/posts';
+import styles from './Blog.module.css';
 
 interface BlogProps {
   posts?: PostMeta[];
@@ -8,9 +9,9 @@ interface BlogProps {
 
 export default function Blog({ posts = [] }: BlogProps) {
   return (
-    <section id="blog" className="blog container">
+    <section id="blog" className={`container ${styles.blog}`}>
       <h2 className="heading-font">Blog</h2>
-      <div className="blog-grid">
+      <div className={styles.blogGrid}>
         {posts.map((post) => (
           <article key={post.slug} className="card">
             {post.image && (

--- a/components/BookAnimation.module.css
+++ b/components/BookAnimation.module.css
@@ -1,0 +1,67 @@
+.bookAnimation {
+  position: relative;
+  width: 120px;
+  height: 80px;
+  perspective: 1000px;
+  margin: 0 auto 2rem;
+}
+
+.book {
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+}
+
+.page {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--color-white);
+  transform-origin: left;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);
+  backface-visibility: hidden;
+}
+
+.page:nth-child(1) {
+  z-index: 3;
+  animation: pageTurn1 4s infinite;
+}
+
+.page:nth-child(2) {
+  z-index: 2;
+  animation: pageTurn2 4s infinite;
+}
+
+.page:nth-child(3) {
+  z-index: 1;
+  animation: pageTurn3 4s infinite;
+}
+
+@keyframes pageTurn1 {
+  0%, 20% {
+    transform: rotateY(0);
+  }
+  40%, 100% {
+    transform: rotateY(-180deg);
+  }
+}
+
+@keyframes pageTurn2 {
+  0%, 40% {
+    transform: rotateY(0);
+  }
+  60%, 100% {
+    transform: rotateY(-180deg);
+  }
+}
+
+@keyframes pageTurn3 {
+  0%, 60% {
+    transform: rotateY(0);
+  }
+  80%, 100% {
+    transform: rotateY(-180deg);
+  }
+}

--- a/components/BookAnimation.tsx
+++ b/components/BookAnimation.tsx
@@ -1,10 +1,12 @@
+import styles from './BookAnimation.module.css';
+
 export default function BookAnimation() {
   return (
-    <div className="book-animation" aria-hidden="true">
-      <div className="book">
-        <div className="page" />
-        <div className="page" />
-        <div className="page" />
+    <div className={styles.bookAnimation} aria-hidden="true">
+      <div className={styles.book}>
+        <div className={styles.page} />
+        <div className={styles.page} />
+        <div className={styles.page} />
       </div>
     </div>
   );

--- a/components/ContactForm.module.css
+++ b/components/ContactForm.module.css
@@ -1,0 +1,4 @@
+.form {
+  max-width: 500px;
+  margin: 0 auto;
+}

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import styles from './ContactForm.module.css';
 
 interface FormState {
   name: string;
@@ -55,7 +56,7 @@ export default function ContactForm() {
   };
 
   return (
-    <form id="contact-form" className="contact-form" onSubmit={handleSubmit} noValidate>
+    <form id="contact-form" className={styles.form} onSubmit={handleSubmit} noValidate>
       <div className="form-group">
         <label htmlFor="name">Name</label>
         <input

--- a/components/Hero.module.css
+++ b/components/Hero.module.css
@@ -1,0 +1,76 @@
+.hero {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: var(--color-white);
+  height: 100vh;
+  background: url('https://images.unsplash.com/photo-1519682337058-a94d519337bc?auto=format&fit=crop&w=2400&q=80') center/cover no-repeat;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  height: 100%;
+  padding: 2rem;
+}
+
+.hero::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+.hero h1 {
+  font-size: 3rem;
+}
+
+.hero p {
+  font-size: 1.5rem;
+}
+
+@media (max-width: 600px) {
+  .content {
+    padding: 1.5rem;
+  }
+
+  .hero h1 {
+    font-size: 2rem;
+  }
+
+  .hero p {
+    font-size: 1rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .hero h1 {
+    font-size: 4rem;
+  }
+
+  .hero p {
+    font-size: 2rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .hero h1 {
+    font-size: 5rem;
+  }
+
+  .hero p {
+    font-size: 2.5rem;
+  }
+}

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,4 +1,5 @@
 import BookAnimation from './BookAnimation';
+import styles from './Hero.module.css';
 
 export default function Hero() {
   const scrollToQuote = (): void => {
@@ -7,8 +8,8 @@ export default function Hero() {
     }
   };
   return (
-    <section className="hero" id="hero">
-      <div className="hero-content container">
+    <section className={styles.hero} id="hero">
+      <div className={`container ${styles.content}`}>
         <BookAnimation />
         <h1 className="heading-font">Handcrafted Bookbinding</h1>
         <p>Precision Bookbinding &amp; Finishing</p>

--- a/components/Navbar.module.css
+++ b/components/Navbar.module.css
@@ -1,0 +1,98 @@
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--color-black);
+  color: var(--color-white);
+  padding: 1em;
+  flex-wrap: wrap;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  margin-right: 1em;
+}
+
+.logo img {
+  height: 40px;
+  width: auto;
+  display: block;
+}
+
+.navLinks {
+  list-style: none;
+  display: flex;
+  gap: 1em;
+  margin: 0;
+  padding: 0;
+  align-items: center;
+}
+
+.navLinks a {
+  color: var(--color-white);
+  text-decoration: none;
+  position: relative;
+  transition: color 0.3s ease;
+}
+
+.navLinks a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -2px;
+  width: 100%;
+  height: 2px;
+  background: var(--color-accent);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.3s ease;
+}
+
+.navLinks a:hover::after,
+.navLinks a:focus::after,
+.active::after {
+  transform: scaleX(1);
+}
+
+.navLinks a:hover,
+.navLinks a:focus,
+.active {
+  color: var(--color-accent);
+}
+
+.navToggle {
+  display: none;
+  background: none;
+  border: none;
+  color: var(--color-white);
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0.25em 0.5em;
+}
+
+@media (max-width: 768px) {
+  .navToggle {
+    display: block;
+  }
+
+  .navLinks {
+    flex-direction: column;
+    width: 100%;
+    background: var(--color-black);
+    margin-top: 1em;
+    max-height: 0;
+    overflow: hidden;
+    opacity: 0;
+    transform: translateY(-10px);
+    pointer-events: none;
+    transition: max-height 0.3s ease, opacity 0.3s ease, transform 0.3s ease;
+  }
+
+  .open {
+    max-height: 500px;
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/router';
 import Image from 'next/image';
 import { motion } from 'framer-motion';
+import styles from './Navbar.module.css';
 
 export default function Navbar() {
   const [open, setOpen] = useState<boolean>(false);
@@ -11,8 +12,8 @@ export default function Navbar() {
   const router = useRouter();
   const isActive = (path: string): boolean => router.pathname === path;
   return (
-    <header className="navbar">
-      <Link href="/" className="logo" onClick={close}>
+    <header className={styles.navbar}>
+      <Link href="/" className={styles.logo} onClick={close}>
         <Image
           src={`${router.basePath}/logo.svg`}
           alt="Fouad Baayno Bookbindery logo"
@@ -21,36 +22,36 @@ export default function Navbar() {
         />
       </Link>
       <nav>
-        <ul id="nav-links" className={`nav-links ${open ? 'open' : ''}`}>
+        <ul id="nav-links" className={`${styles.navLinks} ${open ? styles.open : ''}`}>
           <li>
-            <Link href="/" onClick={close} className={isActive('/') ? 'active' : ''}>
+            <Link href="/" onClick={close} className={isActive('/') ? styles.active : ''}>
               Home
             </Link>
           </li>
           <li>
-            <Link href="/services" onClick={close} className={isActive('/services') ? 'active' : ''}>
+            <Link href="/services" onClick={close} className={isActive('/services') ? styles.active : ''}>
               Services
             </Link>
           </li>
           <li>
-            <Link href="/portfolio" onClick={close} className={isActive('/portfolio') ? 'active' : ''}>
+            <Link href="/portfolio" onClick={close} className={isActive('/portfolio') ? styles.active : ''}>
               Portfolio
             </Link>
           </li>
           <li>
-            <Link href="/blog" onClick={close} className={isActive('/blog') ? 'active' : ''}>
+            <Link href="/blog" onClick={close} className={isActive('/blog') ? styles.active : ''}>
               Blog
             </Link>
           </li>
           <li>
-            <Link href="/contact" onClick={close} className={isActive('/contact') ? 'active' : ''}>
+            <Link href="/contact" onClick={close} className={isActive('/contact') ? styles.active : ''}>
               Contact
             </Link>
           </li>
         </ul>
       </nav>
       <motion.button
-        id="nav-toggle"
+        className={styles.navToggle}
         aria-label="Toggle navigation"
         aria-controls="nav-links"
         aria-expanded={open}

--- a/components/Portfolio.module.css
+++ b/components/Portfolio.module.css
@@ -1,0 +1,54 @@
+.portfolio {
+  margin-top: 2em;
+}
+
+.portfolioGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2em;
+}
+
+.lightbox {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: none;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  z-index: 1000;
+}
+
+.open {
+  display: flex;
+}
+
+.lightbox img {
+  max-width: 90%;
+  max-height: 80%;
+  border-radius: var(--radius);
+}
+
+.lightboxClose {
+  color: var(--color-white);
+  font-size: 2rem;
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  cursor: pointer;
+}
+
+.lightboxCaption {
+  color: var(--color-white);
+  margin-top: 0.5em;
+}
+
+@media (min-width: 1024px) {
+  .portfolioGrid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}

--- a/components/Portfolio.tsx
+++ b/components/Portfolio.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 import { useState } from 'react';
+import styles from './Portfolio.module.css';
 
 interface PortfolioItem {
   img: string;
@@ -42,9 +43,9 @@ export default function Portfolio() {
   };
 
   return (
-    <section id="portfolio" className="portfolio container">
+    <section id="portfolio" className={`container ${styles.portfolio}`}>
       <h2 className="heading-font">Portfolio</h2>
-      <div className="portfolio-grid">
+      <div className={styles.portfolioGrid}>
         {portfolioData.map((item, idx) => (
           <article key={idx} className="card">
             <Image
@@ -62,14 +63,14 @@ export default function Portfolio() {
       </div>
       {selected && (
         <div
-          className="lightbox open"
+          className={`${styles.lightbox} ${styles.open}`}
           style={{
             opacity: lightboxOpen ? 1 : 0,
             transition: 'opacity 0.3s ease'
           }}
           onClick={closeLightbox}
         >
-          <span className="lightbox-close" onClick={closeLightbox}>
+          <span className={styles.lightboxClose} onClick={closeLightbox}>
             &times;
           </span>
           <div onClick={(e) => e.stopPropagation()}>
@@ -80,7 +81,7 @@ export default function Portfolio() {
               height={600}
               style={{ width: '100%', height: 'auto' }}
             />
-            <div className="lightbox-caption">{selected.title}</div>
+            <div className={styles.lightboxCaption}>{selected.title}</div>
           </div>
         </div>
       )}

--- a/components/QuoteForm.module.css
+++ b/components/QuoteForm.module.css
@@ -1,0 +1,8 @@
+.quote {
+  margin-top: 2em;
+}
+
+.form {
+  max-width: 500px;
+  margin: 0 auto;
+}

--- a/components/QuoteForm.tsx
+++ b/components/QuoteForm.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import styles from './QuoteForm.module.css';
 
 interface QuoteFormState {
   name: string;
@@ -61,10 +62,10 @@ export default function QuoteForm() {
   };
 
   return (
-    <section id="quote" className="quote">
+    <section id="quote" className={styles.quote}>
       <div className="container">
         <h2 className="heading-font">Request a Quote</h2>
-        <form className="quote-form" onSubmit={handleSubmit} noValidate>
+        <form className={styles.form} onSubmit={handleSubmit} noValidate>
           <div className="form-group">
             <label htmlFor="quote-name">Name</label>
             <input

--- a/components/Services.module.css
+++ b/components/Services.module.css
@@ -1,0 +1,10 @@
+.services {
+  margin-top: 2em;
+}
+
+.serviceGrid {
+  margin-top: 2em;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+}

--- a/components/Services.tsx
+++ b/components/Services.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import styles from './Services.module.css';
 
 interface Service {
   icon?: string;
@@ -17,9 +18,9 @@ export default function Services() {
   }, []);
 
   return (
-    <section id="services" className="services container">
+    <section id="services" className={`container ${styles.services}`}>
       <h2 className="heading-font">Services</h2>
-      <div className="service-grid">
+      <div className={styles.serviceGrid}>
         {services.map((service, idx) => (
           <article key={idx} className="card">
             {service.icon && <div className="icon">{service.icon}</div>}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -40,6 +40,7 @@ a {
     color-scheme: dark;
   }
 }
+
 /* Font declarations */
 @font-face {
     font-family: 'Open Sans';
@@ -132,168 +133,7 @@ body {
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-
-.navbar {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    background: var(--color-black);
-    color: var(--color-white);
-    padding: 1em;
-    flex-wrap: wrap;
-}
-
-.logo {
-    display: flex;
-    align-items: center;
-    margin-right: 1em;
-}
-
-.logo img {
-    height: 40px;
-    width: auto;
-    display: block;
-}
-
-
-.nav-links {
-    list-style: none;
-    display: flex;
-    gap: 1em;
-    margin: 0;
-    padding: 0;
-    align-items: center;
-}
-
-.nav-links a {
-    color: var(--color-white);
-    text-decoration: none;
-    position: relative;
-    transition: color 0.3s ease;
-}
-
-.nav-links a::after {
-    content: "";
-    position: absolute;
-    left: 0;
-    bottom: -2px;
-    width: 100%;
-    height: 2px;
-    background: var(--color-accent);
-    transform: scaleX(0);
-    transform-origin: left;
-    transition: transform 0.3s ease;
-}
-
-@media (min-width: 768px) {
-    .nav-links a:hover::after,
-    .nav-links a:focus::after,
-    .nav-links a.active::after {
-        transform: scaleX(1);
-    }
-}
-
-.nav-links a:hover,
-.nav-links a:focus {
-    color: var(--color-accent);
-}
-
-.nav-links a.active {
-    color: var(--color-accent);
-}
-
-#nav-toggle {
-    display: none;
-    background: none;
-    border: none;
-    color: var(--color-white);
-    font-size: 1.5rem;
-    cursor: pointer;
-    padding: 0.25em 0.5em;
-}
-
-
-.hero {
-    position: relative;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    color: var(--color-white);
-    height: 100vh;
-    background: url('https://images.unsplash.com/photo-1519682337058-a94d519337bc?auto=format&fit=crop&w=2400&q=80') center/cover no-repeat;
-}
-
-.hero .container {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    text-align: center;
-    height: 100%;
-    padding: 2rem;
-}
-
-.hero::before {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.5);
-}
-
-.hero > * {
-    position: relative;
-    z-index: 1;
-}
-
-.hero h1 {
-    font-size: 3rem;
-}
-
-.hero p {
-    font-size: 1.5rem;
-}
-
-@media (max-width: 600px) {
-    .hero .container {
-        padding: 1.5rem;
-    }
-    .hero h1 {
-        font-size: 2rem;
-    }
-
-    .hero p {
-        font-size: 1rem;
-    }
-}
-header {
-}
-
-main {
-    padding: 2em;
-    text-align: center;
-}
-
-.about {
-    margin-top: 2em;
-}
-
-.about p {
-    max-width: 800px;
-    margin: 0.5em auto 0;
-}
-
-.services,
-.portfolio-grid,
-.blog-grid {
-    margin-top: 2em;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 1.5rem;
-}
-
+/* Shared components */
 .card {
     background: var(--color-white);
     padding: 1em;
@@ -321,39 +161,10 @@ main {
     box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
 }
 
-.card h3 {
-    margin-top: 0;
-}
-
-.contact {
-    margin-top: 2em;
-}
-
-.quote {
-    margin-top: 2em;
-}
-
-.faqs {
-    margin-top: 2em;
-}
-
-.contact-form,
-.quote-form {
-    max-width: 500px;
-    margin: 0 auto;
-}
-
+/* Form elements */
 .form-group {
     margin-bottom: 1em;
     text-align: left;
-}
-
-.faq {
-    margin-bottom: 1em;
-}
-
-.faq h3 {
-    margin-bottom: 0.5em;
 }
 
 .form-group label {
@@ -389,60 +200,7 @@ main {
     display: block;
 }
 
-.quote-form button[type="submit"] {
-    background: var(--color-accent);
-    color: var(--color-white);
-}
-
-.testimonials {
-    margin-top: 2em;
-}
-
-.testimonial-carousel {
-    position: relative;
-    max-width: 500px;
-    margin: 0 auto;
-    min-height: 180px;
-}
-
-.testimonial {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    padding: 1em;
-    background: var(--color-white);
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    opacity: 0;
-    transition: opacity 0.5s ease;
-}
-
-.testimonial.active {
-    position: relative;
-    opacity: 1;
-}
-
-.carousel-btn {
-    position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    background: rgba(0, 0, 0, 0.5);
-    color: var(--color-white);
-    border: none;
-    border-radius: 50%;
-    width: 30px;
-    height: 30px;
-    cursor: pointer;
-}
-
-.carousel-btn.prev {
-    left: 10px;
-}
-
-.carousel-btn.next {
-    right: 10px;
-}
+/* Buttons */
 button {
     padding: var(--btn-padding);
     font-size: 1em;
@@ -452,6 +210,12 @@ button {
     border-radius: var(--radius);
     cursor: pointer;
     transition: all 0.3s ease;
+}
+
+button:hover,
+button:focus {
+    background: var(--color-accent-dark);
+    transform: translateY(-2px);
 }
 
 .btn {
@@ -474,11 +238,6 @@ button {
     transform: translateY(-2px);
 }
 
-button:hover,
-button:focus {
-    background: var(--color-accent-dark);
-    transform: translateY(-2px);
-}
 footer {
     text-align: center;
     padding: 1em;
@@ -487,138 +246,6 @@ footer {
     position: fixed;
     width: 100%;
     bottom: 0;
-}
-
-.gallery-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-    gap: 1em;
-}
-
-.gallery-grid figure {
-    margin: 0;
-}
-
-.gallery-grid img {
-    width: 100%;
-    display: block;
-    border-radius: var(--radius);
-    cursor: pointer;
-}
-
-.lightbox {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.8);
-    display: none;
-    justify-content: center;
-    align-items: center;
-    flex-direction: column;
-    z-index: 1000;
-}
-
-.lightbox.open {
-    display: flex;
-}
-
-.lightbox img {
-    max-width: 90%;
-    max-height: 80%;
-    border-radius: var(--radius);
-}
-
-.lightbox-close {
-    color: var(--color-white);
-    font-size: 2rem;
-    position: absolute;
-    top: 1rem;
-    right: 1rem;
-    cursor: pointer;
-}
-
-.lightbox-caption {
-    color: var(--color-white);
-    margin-top: 0.5em;
-}
-
-@media (max-width: 768px) {
-    #nav-toggle {
-        display: block;
-    }
-
-    .nav-links {
-        flex-direction: column;
-        width: 100%;
-        background: var(--color-black);
-        margin-top: 1em;
-        max-height: 0;
-        overflow: hidden;
-        opacity: 0;
-        transform: translateY(-10px);
-        pointer-events: none;
-        transition: max-height 0.3s ease, opacity 0.3s ease, transform 0.3s ease;
-    }
-
-    .nav-links.open {
-        max-height: 500px;
-        opacity: 1;
-        transform: translateY(0);
-        pointer-events: auto;
-    }
-}
-
-@media (min-width: 768px) {
-    .container {
-        padding: 0 2em;
-    }
-
-    .hero h1 {
-        font-size: 4rem;
-    }
-
-    .hero p {
-        font-size: 2rem;
-    }
-
-
-    .testimonial-carousel {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-        gap: 1.5em;
-        position: static;
-        max-width: none;
-        min-height: 0;
-    }
-
-    .testimonial {
-        position: relative;
-        opacity: 1;
-    }
-
-    .carousel-btn {
-        display: none;
-    }
-}
-
-@media (min-width: 1024px) {
-    .container {
-        max-width: 1400px;
-    }
-
-    .hero h1 {
-        font-size: 5rem;
-    }
-
-    .hero p {
-        font-size: 2.5rem;
-    }
-
-    .gallery-grid {
-        grid-template-columns: repeat(3, 1fr);
-    }
 }
 
 /* Fade-in animation for sections */
@@ -632,65 +259,16 @@ section {
     transform: translateY(0);
     transition: opacity 0.6s ease-out, transform 0.6s ease-out;
 }
-/* Book animation */
-.hero .book-animation {
-    margin: 0 auto 2rem;
-}
-.book-animation {
-    position: relative;
-    width: 120px;
-    height: 80px;
-    perspective: 1000px;
-}
-.book {
-    width: 100%;
-    height: 100%;
-    transform-style: preserve-3d;
-}
-.page {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: var(--color-white);
-    transform-origin: left;
-    box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);
-    backface-visibility: hidden;
-}
-.page:nth-child(1) {
-    z-index: 3;
-    animation: pageTurn1 4s infinite;
-}
-.page:nth-child(2) {
-    z-index: 2;
-    animation: pageTurn2 4s infinite;
-}
-.page:nth-child(3) {
-    z-index: 1;
-    animation: pageTurn3 4s infinite;
-}
-@keyframes pageTurn1 {
-    0%, 20% {
-        transform: rotateY(0);
-    }
-    40%, 100% {
-        transform: rotateY(-180deg);
+
+@media (min-width: 768px) {
+    .container {
+        padding: 0 2em;
     }
 }
-@keyframes pageTurn2 {
-    0%, 40% {
-        transform: rotateY(0);
-    }
-    60%, 100% {
-        transform: rotateY(-180deg);
+
+@media (min-width: 1024px) {
+    .container {
+        max-width: 1400px;
     }
 }
-@keyframes pageTurn3 {
-    0%, 60% {
-        transform: rotateY(0);
-    }
-    80%, 100% {
-        transform: rotateY(-180deg);
-    }
-}
+


### PR DESCRIPTION
## Summary
- move Navbar, Hero, and other component styles into dedicated CSS modules
- trim `globals.css` to resets and shared utilities
- update React components to load their own style modules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a84b186e2c832e802d23c22ccba342