### PR TITLE
feat: add theme toggle

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import Image from 'next/image';
 import { motion } from 'framer-motion';
@@ -7,10 +7,24 @@ import styles from './Navbar.module.css';
 
 export default function Navbar() {
   const [open, setOpen] = useState<boolean>(false);
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
   const toggle = (): void => setOpen(!open);
   const close = (): void => setOpen(false);
+  const toggleTheme = (): void => {
+    const newTheme = theme === 'light' ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-theme', newTheme);
+    localStorage.setItem('theme', newTheme);
+    setTheme(newTheme);
+  };
   const router = useRouter();
   const isActive = (path: string): boolean => router.pathname === path;
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme') as 'light' | 'dark' | null;
+    const initialTheme = stored ?? 'light';
+    document.documentElement.setAttribute('data-theme', initialTheme);
+    setTheme(initialTheme);
+  }, []);
   return (
     <header className={styles.navbar}>
       <Link href="/" className={styles.logo} onClick={close}>
@@ -50,6 +64,9 @@ export default function Navbar() {
           </li>
         </ul>
       </nav>
+      <button onClick={toggleTheme} aria-label="Toggle theme">
+        {theme === 'light' ? 'Dark' : 'Light'}
+      </button>
       <motion.button
         className={styles.navToggle}
         aria-label="Toggle navigation"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,13 +1,13 @@
-:root {
+html[data-theme="light"] {
   --background: #ffffff;
   --foreground: #171717;
+  color-scheme: light;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+html[data-theme="dark"] {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+  color-scheme: dark;
 }
 
 html,
@@ -35,11 +35,7 @@ a {
   text-decoration: none;
 }
 
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
-}
+/* Theme-specific styles are handled via the data-theme attribute */
 
 /* Font declarations */
 @font-face {
@@ -61,7 +57,8 @@ a {
     src: url('https://fonts.cdnfonts.com/s/13982/CaeciliaLTStd-BoldItalic.woff') format('woff');
 }
 
-:root {
+html[data-theme="light"],
+html[data-theme="dark"] {
     --color-black: #0b0b0b;
     --color-white: #ffffff;
     --color-red: #d61f26;
@@ -113,8 +110,8 @@ h1, h2, h3, h4, h5, h6 {
 body {
     margin: 0;
     padding: 0;
-    background: var(--color-white);
-    color: var(--color-black);
+    background: var(--background);
+    color: var(--foreground);
     font-family: var(--font-body);
     font-weight: var(--fw-normal);
 }


### PR DESCRIPTION
## Summary
- add theme toggle to navbar and persist selection
- style globals with data-theme attributes for dark and light

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a84ce3b62c832e9c24e53c0ec03486