### PR TITLE
feat: animated hero with video background

### DIFF
--- a/components/Hero.module.css
+++ b/components/Hero.module.css
@@ -5,7 +5,7 @@
   align-items: center;
   color: var(--color-white);
   height: 100vh;
-  background: url('https://images.unsplash.com/photo-1519682337058-a94d519337bc?auto=format&fit=crop&w=2400&q=80') center/cover no-repeat;
+  overflow: hidden;
 }
 
 .content {
@@ -26,12 +26,20 @@
   right: 0;
   bottom: 0;
   background: rgba(0, 0, 0, 0.5);
+  z-index: 1;
 }
 
 .hero > * {
   position: relative;
-  z-index: 1;
+  z-index: 2;
 }
+
+@media (max-width: 768px) {
+  .hero {
+    background: url('https://images.unsplash.com/photo-1495446815901-a7297e633e8d?auto=format&fit=crop&w=1280&q=80') center/cover no-repeat;
+  }
+}
+
 
 .hero h1 {
   font-size: 3rem;

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,7 +1,21 @@
 import BookAnimation from './BookAnimation';
 import styles from './Hero.module.css';
+import { motion } from 'framer-motion';
+import { useEffect, useState } from 'react';
 
 export default function Hero() {
+  const [showVideo, setShowVideo] = useState(false);
+
+  useEffect(() => {
+    const handleResize = (): void => {
+      setShowVideo(window.innerWidth >= 768);
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
   const scrollToQuote = (): void => {
     if (typeof document !== 'undefined') {
       document.getElementById('quote')?.scrollIntoView({ behavior: 'smooth' });
@@ -9,17 +23,44 @@ export default function Hero() {
   };
   return (
     <section className={styles.hero} id="hero">
+      {showVideo && (
+        <video
+          className="background-video"
+          autoPlay
+          loop
+          muted
+          playsInline
+          preload="none"
+          poster="https://images.unsplash.com/photo-1495446815901-a7297e633e8d?auto=format&fit=crop&w=1280&q=80"
+          aria-hidden="true"
+        >
+          <source
+            src="https://cdn.coverr.co/videos/coverr-reading-a-book-7985/1080p.mp4"
+            type="video/mp4"
+          />
+        </video>
+      )}
       <div className={`container ${styles.content}`}>
         <BookAnimation />
-        <h1 className="heading-font">Handcrafted Bookbinding</h1>
+        <motion.h1
+          className="heading-font"
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+        >
+          Handcrafted Bookbinding
+        </motion.h1>
         <p>Precision Bookbinding &amp; Finishing</p>
-        <button
+        <motion.button
           className="btn btn-primary"
           onClick={scrollToQuote}
           aria-label="Request a Quote"
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.3, duration: 0.6 }}
         >
           Request a Quote
-        </button>
+        </motion.button>
       </div>
     </section>
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -245,6 +245,17 @@ footer {
     bottom: 0;
 }
 
+/* Background video helper */
+.background-video {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    z-index: 0;
+}
+
 /* Fade-in animation for sections */
 section {
     opacity: 0;


### PR DESCRIPTION
## Summary
- replace hero image with looping video and mobile fallback
- animate hero heading and CTA with framer-motion
- add global styles for background video
- avoid downloading hero video on small screens
- serve fallback from remote URL to avoid binary assets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a84dfed0dc832e9b7fce8b84a12346