### PR TITLE
Use masonry grid with motion animations on portfolio cards

### DIFF
--- a/components/Portfolio.module.css
+++ b/components/Portfolio.module.css
@@ -4,9 +4,45 @@
 
 .portfolioGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  grid-auto-rows: 10px;
+  grid-auto-flow: dense;
   gap: 1.5rem;
   margin-top: 2em;
+}
+
+.card {
+  position: relative;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.card img {
+  width: 100%;
+  height: auto;
+  transition: transform 0.3s ease;
+  display: block;
+}
+
+.card:hover img {
+  transform: scale(1.05);
+}
+
+.caption {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 0.5rem;
+  background: rgba(0, 0, 0, 0.6);
+  color: var(--color-white);
+  transform: translateY(100%);
+  transition: transform 0.3s ease;
+  pointer-events: none;
+}
+
+.card:hover .caption {
+  transform: translateY(0);
 }
 
 .lightbox {
@@ -47,8 +83,3 @@
   margin-top: 0.5em;
 }
 
-@media (min-width: 1024px) {
-  .portfolioGrid {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}

--- a/components/Portfolio.tsx
+++ b/components/Portfolio.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 import { useState } from 'react';
+import { motion } from 'framer-motion';
 import styles from './Portfolio.module.css';
 
 interface PortfolioItem {
@@ -29,6 +30,19 @@ const portfolioData: PortfolioItem[] = [
 export default function Portfolio() {
   const [selected, setSelected] = useState<PortfolioItem | null>(null);
   const [lightboxOpen, setLightboxOpen] = useState(false);
+  const [spans, setSpans] = useState<number[]>(portfolioData.map(() => 1));
+
+  const rowHeight = 10;
+
+  const handleLoad = (idx: number, img: HTMLImageElement) => {
+    const height = (img.naturalHeight / img.naturalWidth) * img.width;
+    const span = Math.ceil(height / rowHeight);
+    setSpans((prev) => {
+      const next = [...prev];
+      next[idx] = span;
+      return next;
+    });
+  };
 
   const openLightbox = (item: PortfolioItem) => {
     setSelected(item);
@@ -47,18 +61,29 @@ export default function Portfolio() {
       <h2 className="heading-font">Portfolio</h2>
       <div className={styles.portfolioGrid}>
         {portfolioData.map((item, idx) => (
-          <article key={idx} className="card">
+          <motion.article
+            key={idx}
+            className={`card ${styles.card}`}
+            style={{ gridRowEnd: `span ${spans[idx]}` }}
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.5, delay: idx * 0.1 }}
+            onClick={() => openLightbox(item)}
+          >
             <Image
               src={item.img}
               alt={item.title}
               width={600}
               height={400}
               style={{ width: '100%', height: 'auto' }}
-              onClick={() => openLightbox(item)}
+              onLoadingComplete={(img) => handleLoad(idx, img)}
             />
-            <h3>{item.title}</h3>
-            <p>{item.description}</p>
-          </article>
+            <div className={styles.caption}>
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+            </div>
+          </motion.article>
         ))}
       </div>
       {selected && (


### PR DESCRIPTION
## Summary
- replace portfolio grid with masonry-style CSS grid
- animate portfolio cards using framer-motion and reveal captions on hover

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a8552fb884832e8d970cee42e0a632