### PR TITLE
style: enhance form styles and feedback

### DIFF
--- a/components/ContactForm.module.css
+++ b/components/ContactForm.module.css
@@ -2,3 +2,68 @@
   max-width: 500px;
   margin: 0 auto;
 }
+
+.label {
+  display: block;
+  margin-bottom: 0.5em;
+}
+
+.input,
+.textarea,
+.select {
+  width: 100%;
+  padding: 0.5em;
+  border: 1px solid var(--color-black);
+  border-radius: 4px;
+  font-family: inherit;
+  transition: border-color 0.3s, box-shadow 0.3s;
+}
+
+.textarea {
+  resize: vertical;
+  min-height: 120px;
+}
+
+.input:focus,
+.textarea:focus,
+.select:focus {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 2px rgba(214, 31, 38, 0.2);
+  outline: none;
+}
+
+.input[aria-invalid='true'],
+.textarea[aria-invalid='true'],
+.select[aria-invalid='true'] {
+  border-color: var(--color-red);
+}
+
+.button {
+  padding: var(--btn-padding);
+  font-size: 1em;
+  background: var(--color-accent);
+  color: var(--color-white);
+  border: none;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background 0.3s, transform 0.3s;
+}
+
+.button:hover,
+.button:focus {
+  background: var(--color-accent-dark);
+  transform: translateY(-2px);
+}
+
+.errorMessage {
+  display: block;
+  color: var(--color-accent);
+  font-size: 0.875em;
+  margin-top: 0.25em;
+}
+
+.successMessage {
+  display: block;
+  color: var(--color-gold);
+  margin-top: 1em;
+}

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
 import styles from './ContactForm.module.css';
 
 interface FormState {
@@ -58,7 +59,7 @@ export default function ContactForm() {
   return (
     <form id="contact-form" className={styles.form} onSubmit={handleSubmit} noValidate>
       <div className="form-group">
-        <label htmlFor="name">Name</label>
+        <label htmlFor="name" className={styles.label}>Name</label>
         <input
           type="text"
           id="name"
@@ -67,16 +68,27 @@ export default function ContactForm() {
           onChange={handleChange}
           aria-invalid={!!errors.name}
           aria-describedby={errors.name ? 'name-error' : undefined}
+          className={styles.input}
           required
         />
-        {errors.name && (
-          <span id="name-error" className="error-message" role="alert">
-            {errors.name}
-          </span>
-        )}
+        <AnimatePresence>
+          {errors.name && (
+            <motion.span
+              id="name-error"
+              className={styles.errorMessage}
+              role="alert"
+              initial={{ opacity: 0, y: -5 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -5 }}
+              transition={{ duration: 0.2 }}
+            >
+              {errors.name}
+            </motion.span>
+          )}
+        </AnimatePresence>
       </div>
       <div className="form-group">
-        <label htmlFor="email">Email</label>
+        <label htmlFor="email" className={styles.label}>Email</label>
         <input
           type="email"
           id="email"
@@ -85,16 +97,27 @@ export default function ContactForm() {
           onChange={handleChange}
           aria-invalid={!!errors.email}
           aria-describedby={errors.email ? 'email-error' : undefined}
+          className={styles.input}
           required
         />
-        {errors.email && (
-          <span id="email-error" className="error-message" role="alert">
-            {errors.email}
-          </span>
-        )}
+        <AnimatePresence>
+          {errors.email && (
+            <motion.span
+              id="email-error"
+              className={styles.errorMessage}
+              role="alert"
+              initial={{ opacity: 0, y: -5 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -5 }}
+              transition={{ duration: 0.2 }}
+            >
+              {errors.email}
+            </motion.span>
+          )}
+        </AnimatePresence>
       </div>
       <div className="form-group">
-        <label htmlFor="message">Message</label>
+        <label htmlFor="message" className={styles.label}>Message</label>
         <textarea
           id="message"
           name="message"
@@ -102,25 +125,55 @@ export default function ContactForm() {
           onChange={handleChange}
           aria-invalid={!!errors.message}
           aria-describedby={errors.message ? 'message-error' : undefined}
+          className={styles.textarea}
           required
         ></textarea>
-        {errors.message && (
-          <span id="message-error" className="error-message" role="alert">
-            {errors.message}
-          </span>
-        )}
+        <AnimatePresence>
+          {errors.message && (
+            <motion.span
+              id="message-error"
+              className={styles.errorMessage}
+              role="alert"
+              initial={{ opacity: 0, y: -5 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -5 }}
+              transition={{ duration: 0.2 }}
+            >
+              {errors.message}
+            </motion.span>
+          )}
+        </AnimatePresence>
       </div>
-      <button type="submit" aria-label="Send message">Send</button>
-      {success && (
-        <span className="success-message" role="status" aria-live="polite">
-          {success}
-        </span>
-      )}
-      {submitError && (
-        <span className="error-message" role="alert">
-          {submitError}
-        </span>
-      )}
+      <button type="submit" className={styles.button} aria-label="Send message">Send</button>
+      <AnimatePresence>
+        {success && (
+          <motion.span
+            className={styles.successMessage}
+            role="status"
+            aria-live="polite"
+            initial={{ opacity: 0, y: -5 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -5 }}
+            transition={{ duration: 0.3 }}
+          >
+            {success}
+          </motion.span>
+        )}
+      </AnimatePresence>
+      <AnimatePresence>
+        {submitError && (
+          <motion.span
+            className={styles.errorMessage}
+            role="alert"
+            initial={{ opacity: 0, y: -5 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -5 }}
+            transition={{ duration: 0.3 }}
+          >
+            {submitError}
+          </motion.span>
+        )}
+      </AnimatePresence>
     </form>
   );
 }

--- a/components/QuoteForm.module.css
+++ b/components/QuoteForm.module.css
@@ -6,3 +6,68 @@
   max-width: 500px;
   margin: 0 auto;
 }
+
+.label {
+  display: block;
+  margin-bottom: 0.5em;
+}
+
+.input,
+.textarea,
+.select {
+  width: 100%;
+  padding: 0.5em;
+  border: 1px solid var(--color-black);
+  border-radius: 4px;
+  font-family: inherit;
+  transition: border-color 0.3s, box-shadow 0.3s;
+}
+
+.textarea {
+  resize: vertical;
+  min-height: 120px;
+}
+
+.input:focus,
+.textarea:focus,
+.select:focus {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 2px rgba(214, 31, 38, 0.2);
+  outline: none;
+}
+
+.input[aria-invalid='true'],
+.textarea[aria-invalid='true'],
+.select[aria-invalid='true'] {
+  border-color: var(--color-red);
+}
+
+.button {
+  padding: var(--btn-padding);
+  font-size: 1em;
+  background: var(--color-accent);
+  color: var(--color-white);
+  border: none;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background 0.3s, transform 0.3s;
+}
+
+.button:hover,
+.button:focus {
+  background: var(--color-accent-dark);
+  transform: translateY(-2px);
+}
+
+.errorMessage {
+  display: block;
+  color: var(--color-accent);
+  font-size: 0.875em;
+  margin-top: 0.25em;
+}
+
+.successMessage {
+  display: block;
+  color: var(--color-gold);
+  margin-top: 1em;
+}

--- a/components/QuoteForm.tsx
+++ b/components/QuoteForm.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
 import styles from './QuoteForm.module.css';
 
 interface QuoteFormState {
@@ -67,7 +68,7 @@ export default function QuoteForm() {
         <h2 className="heading-font">Request a Quote</h2>
         <form className={styles.form} onSubmit={handleSubmit} noValidate>
           <div className="form-group">
-            <label htmlFor="quote-name">Name</label>
+            <label htmlFor="quote-name" className={styles.label}>Name</label>
             <input
               type="text"
               id="quote-name"
@@ -76,16 +77,27 @@ export default function QuoteForm() {
               onChange={handleChange}
               aria-invalid={!!errors.name}
               aria-describedby={errors.name ? 'quote-name-error' : undefined}
+              className={styles.input}
               required
             />
-            {errors.name && (
-              <span id="quote-name-error" className="error-message" role="alert">
-                {errors.name}
-              </span>
-            )}
+            <AnimatePresence>
+              {errors.name && (
+                <motion.span
+                  id="quote-name-error"
+                  className={styles.errorMessage}
+                  role="alert"
+                  initial={{ opacity: 0, y: -5 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -5 }}
+                  transition={{ duration: 0.2 }}
+                >
+                  {errors.name}
+                </motion.span>
+              )}
+            </AnimatePresence>
           </div>
           <div className="form-group">
-            <label htmlFor="quote-email">Email</label>
+            <label htmlFor="quote-email" className={styles.label}>Email</label>
             <input
               type="email"
               id="quote-email"
@@ -94,16 +106,27 @@ export default function QuoteForm() {
               onChange={handleChange}
               aria-invalid={!!errors.email}
               aria-describedby={errors.email ? 'quote-email-error' : undefined}
+              className={styles.input}
               required
             />
-            {errors.email && (
-              <span id="quote-email-error" className="error-message" role="alert">
-                {errors.email}
-              </span>
-            )}
+            <AnimatePresence>
+              {errors.email && (
+                <motion.span
+                  id="quote-email-error"
+                  className={styles.errorMessage}
+                  role="alert"
+                  initial={{ opacity: 0, y: -5 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -5 }}
+                  transition={{ duration: 0.2 }}
+                >
+                  {errors.email}
+                </motion.span>
+              )}
+            </AnimatePresence>
           </div>
           <div className="form-group">
-            <label htmlFor="book-type">Book Type</label>
+            <label htmlFor="book-type" className={styles.label}>Book Type</label>
             <select
               id="book-type"
               name="bookType"
@@ -111,6 +134,7 @@ export default function QuoteForm() {
               onChange={handleChange}
               aria-invalid={!!errors.bookType}
               aria-describedby={errors.bookType ? 'book-type-error' : undefined}
+              className={styles.select}
               required
             >
               <option value="">Select a type</option>
@@ -118,14 +142,24 @@ export default function QuoteForm() {
               <option value="paperback">Paperback</option>
               <option value="leather">Leather</option>
             </select>
-            {errors.bookType && (
-              <span id="book-type-error" className="error-message" role="alert">
-                {errors.bookType}
-              </span>
-            )}
+            <AnimatePresence>
+              {errors.bookType && (
+                <motion.span
+                  id="book-type-error"
+                  className={styles.errorMessage}
+                  role="alert"
+                  initial={{ opacity: 0, y: -5 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -5 }}
+                  transition={{ duration: 0.2 }}
+                >
+                  {errors.bookType}
+                </motion.span>
+              )}
+            </AnimatePresence>
           </div>
           <div className="form-group">
-            <label htmlFor="quantity">Quantity</label>
+            <label htmlFor="quantity" className={styles.label}>Quantity</label>
             <input
               type="number"
               id="quantity"
@@ -135,29 +169,65 @@ export default function QuoteForm() {
               onChange={handleChange}
               aria-invalid={!!errors.quantity}
               aria-describedby={errors.quantity ? 'quantity-error' : undefined}
+              className={styles.input}
               required
             />
-            {errors.quantity && (
-              <span id="quantity-error" className="error-message" role="alert">
-                {errors.quantity}
-              </span>
-            )}
+            <AnimatePresence>
+              {errors.quantity && (
+                <motion.span
+                  id="quantity-error"
+                  className={styles.errorMessage}
+                  role="alert"
+                  initial={{ opacity: 0, y: -5 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -5 }}
+                  transition={{ duration: 0.2 }}
+                >
+                  {errors.quantity}
+                </motion.span>
+              )}
+            </AnimatePresence>
           </div>
           <div className="form-group">
-            <label htmlFor="quote-notes">Notes</label>
-            <textarea id="quote-notes" name="notes" value={form.notes} onChange={handleChange}></textarea>
+            <label htmlFor="quote-notes" className={styles.label}>Notes</label>
+            <textarea
+              id="quote-notes"
+              name="notes"
+              value={form.notes}
+              onChange={handleChange}
+              className={styles.textarea}
+            ></textarea>
           </div>
-          <button type="submit" aria-label="Submit quote request">Submit</button>
-          {success && (
-            <span className="success-message" role="status" aria-live="polite">
-              {success}
-            </span>
-          )}
-          {submitError && (
-            <span className="error-message" role="alert">
-              {submitError}
-            </span>
-          )}
+          <button type="submit" className={styles.button} aria-label="Submit quote request">Submit</button>
+          <AnimatePresence>
+            {success && (
+              <motion.span
+                className={styles.successMessage}
+                role="status"
+                aria-live="polite"
+                initial={{ opacity: 0, y: -5 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -5 }}
+                transition={{ duration: 0.3 }}
+              >
+                {success}
+              </motion.span>
+            )}
+          </AnimatePresence>
+          <AnimatePresence>
+            {submitError && (
+              <motion.span
+                className={styles.errorMessage}
+                role="alert"
+                initial={{ opacity: 0, y: -5 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -5 }}
+                transition={{ duration: 0.3 }}
+              >
+                {submitError}
+              </motion.span>
+            )}
+          </AnimatePresence>
         </form>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add module-level styling for form labels, inputs, selects, and buttons
- highlight focus and invalid states with smooth transitions
- animate success and error messages with framer-motion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a8610ee10c832e81e091ca58af2834