### PR TITLE
Default to dark theme with accent CSS variables

### DIFF
--- a/components/Card.module.css
+++ b/components/Card.module.css
@@ -2,7 +2,7 @@
   background: var(--color-white);
   padding: 1em;
   border-radius: var(--radius);
-  border-top: 4px solid var(--color-accent);
+  border-top: 4px solid var(--accent);
   box-shadow: var(--shadow, 0 2px 4px rgba(0, 0, 0, 0.1));
   transition: transform 0.3s ease, box-shadow 0.3s ease;
 }

--- a/components/ContactForm.module.css
+++ b/components/ContactForm.module.css
@@ -27,7 +27,7 @@
 .input:focus,
 .textarea:focus,
 .select:focus {
-  border-color: var(--color-accent);
+  border-color: var(--accent);
   box-shadow: 0 0 0 2px rgba(214, 31, 38, 0.2);
   outline: none;
 }
@@ -41,7 +41,7 @@
 .button {
   padding: var(--btn-padding);
   font-size: 1em;
-  background: var(--color-accent);
+  background: var(--accent);
   color: var(--color-white);
   border: none;
   border-radius: var(--radius);
@@ -51,13 +51,18 @@
 
 .button:hover,
 .button:focus {
-  background: var(--color-accent-dark);
+  background: var(--accent-hover);
   transform: translateY(-2px);
+}
+
+.button:active {
+  background: var(--accent-active);
+  transform: translateY(0);
 }
 
 .errorMessage {
   display: block;
-  color: var(--color-accent);
+  color: var(--accent);
   font-size: 0.875em;
   margin-top: 0.25em;
 }

--- a/components/Navbar.module.css
+++ b/components/Navbar.module.css
@@ -43,7 +43,7 @@
   bottom: -2px;
   width: 100%;
   height: 2px;
-  background: var(--color-accent);
+  background: var(--accent);
   transform: scaleX(0);
   transform-origin: left;
   transition: transform 0.3s ease;
@@ -58,7 +58,7 @@
 .navLinks a:hover,
 .navLinks a:focus,
 .active {
-  color: var(--color-accent);
+  color: var(--accent);
 }
 
 .navToggle {

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -7,7 +7,7 @@ import styles from './Navbar.module.css';
 
 export default function Navbar() {
   const [open, setOpen] = useState<boolean>(false);
-  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+  const [theme, setTheme] = useState<'light' | 'dark'>('dark');
   const toggle = (): void => setOpen(!open);
   const close = (): void => setOpen(false);
   const toggleTheme = (): void => {
@@ -21,7 +21,7 @@ export default function Navbar() {
 
   useEffect(() => {
     const stored = localStorage.getItem('theme') as 'light' | 'dark' | null;
-    const initialTheme = stored ?? 'light';
+    const initialTheme = stored ?? 'dark';
     document.documentElement.setAttribute('data-theme', initialTheme);
     setTheme(initialTheme);
   }, []);

--- a/components/QuoteForm.module.css
+++ b/components/QuoteForm.module.css
@@ -31,7 +31,7 @@
 .input:focus,
 .textarea:focus,
 .select:focus {
-  border-color: var(--color-accent);
+  border-color: var(--accent);
   box-shadow: 0 0 0 2px rgba(214, 31, 38, 0.2);
   outline: none;
 }
@@ -45,7 +45,7 @@
 .button {
   padding: var(--btn-padding);
   font-size: 1em;
-  background: var(--color-accent);
+  background: var(--accent);
   color: var(--color-white);
   border: none;
   border-radius: var(--radius);
@@ -55,13 +55,18 @@
 
 .button:hover,
 .button:focus {
-  background: var(--color-accent-dark);
+  background: var(--accent-hover);
   transform: translateY(-2px);
+}
+
+.button:active {
+  background: var(--accent-active);
+  transform: translateY(0);
 }
 
 .errorMessage {
   display: block;
-  color: var(--color-accent);
+  color: var(--accent);
   font-size: 0.875em;
   margin-top: 0.25em;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,12 +1,18 @@
 html[data-theme="light"] {
   --background: #ffffff;
-  --foreground: #171717;
+  --foreground: #000000;
+  --accent: #d61f26;
+  --accent-hover: #b3191f;
+  --accent-active: #8f1419;
   color-scheme: light;
 }
 
 html[data-theme="dark"] {
-  --background: #0a0a0a;
-  --foreground: #ededed;
+  --background: #1a1a1a;
+  --foreground: #d61f26;
+  --accent: #d61f26;
+  --accent-hover: #b3191f;
+  --accent-active: #8f1419;
   color-scheme: dark;
 }
 
@@ -62,8 +68,6 @@ html[data-theme="dark"] {
     --color-black: #0b0b0b;
     --color-white: #ffffff;
     --color-red: #d61f26;
-    --color-accent: var(--color-red); /* switch to var(--color-black) for gold/black theme */
-    --color-accent-dark: #a3181e;
     --color-gold: #c9a227;
     --font-body: 'Open Sans', sans-serif;
     --font-heading: 'caecilia_lt_std55_roman', serif;
@@ -87,7 +91,7 @@ html[data-theme="dark"] {
 
 .gradient-bg {
     min-height: 100vh;
-    background: linear-gradient(-45deg, var(--color-gold), var(--color-accent));
+    background: linear-gradient(-45deg, var(--color-gold), var(--accent));
     background-size: 400% 400%;
     animation: gold-accent-gradient 15s ease infinite;
 }
@@ -156,36 +160,41 @@ body {
     min-height: 120px;
 }
 
-.error-message {
-    display: block;
-    color: var(--color-accent);
-    font-size: 0.875em;
-    margin-top: 0.25em;
-}
+  .error-message {
+      display: block;
+      color: var(--accent);
+      font-size: 0.875em;
+      margin-top: 0.25em;
+  }
 
-.success-message {
-    color: var(--color-accent);
-    margin-top: 1em;
-    display: block;
-}
+  .success-message {
+      color: var(--accent);
+      margin-top: 1em;
+      display: block;
+  }
 
 /* Buttons */
-button {
-    padding: var(--btn-padding);
-    font-size: 1em;
-    background: var(--color-accent);
-    color: var(--color-white);
-    border: none;
-    border-radius: var(--radius);
-    cursor: pointer;
-    transition: all 0.3s ease;
-}
+  button {
+      padding: var(--btn-padding);
+      font-size: 1em;
+      background: var(--accent);
+      color: var(--color-white);
+      border: none;
+      border-radius: var(--radius);
+      cursor: pointer;
+      transition: all 0.3s ease;
+  }
 
-button:hover,
-button:focus {
-    background: var(--color-accent-dark);
-    transform: translateY(-2px);
-}
+  button:hover,
+  button:focus {
+      background: var(--accent-hover);
+      transform: translateY(-2px);
+  }
+
+  button:active {
+      background: var(--accent-active);
+      transform: translateY(0);
+  }
 
 .btn {
     display: inline-block;
@@ -196,16 +205,21 @@ button:focus {
     transition: background 0.3s, color 0.3s, transform 0.3s;
 }
 
-.btn-primary {
-    background: var(--color-accent);
-    color: var(--color-white);
-}
+  .btn-primary {
+      background: var(--accent);
+      color: var(--color-white);
+  }
 
-.btn-primary:hover,
-.btn-primary:focus {
-    background: var(--color-accent-dark);
-    transform: translateY(-2px);
-}
+  .btn-primary:hover,
+  .btn-primary:focus {
+      background: var(--accent-hover);
+      transform: translateY(-2px);
+  }
+
+  .btn-primary:active {
+      background: var(--accent-active);
+      transform: translateY(0);
+  }
 
 footer {
     text-align: center;


### PR DESCRIPTION
## Summary
- define light and dark theme palettes with dedicated accent, hover, and active variables
- switch buttons and links to use the new accent variables
- default navigation theme to dark and persist selection via `data-theme`

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a865148f4c832e997df818e5c97e65