### PR TITLE
Add animated splash screen and page transitions

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,4 +1,6 @@
 import { useEffect, ReactNode } from 'react';
+import { useRouter } from 'next/router';
+import { AnimatePresence, motion } from 'framer-motion';
 import Navbar from './Navbar';
 import LanguageModal from './LanguageModal';
 
@@ -7,6 +9,8 @@ interface LayoutProps {
 }
 
 export default function Layout({ children }: LayoutProps) {
+  const router = useRouter();
+
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
@@ -27,7 +31,7 @@ export default function Layout({ children }: LayoutProps) {
       sections.forEach(sec => observer.unobserve(sec));
       observer.disconnect();
     };
-  }, []);
+  }, [router.asPath]);
 
   return (
     <div className="gradient-bg">
@@ -35,10 +39,21 @@ export default function Layout({ children }: LayoutProps) {
       <div className="sticky-header">
         <Navbar />
       </div>
-      {children}
-      <footer>
-        <p>&copy; 2025 Baayno Website</p>
-      </footer>
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={router.asPath}
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -20 }}
+          transition={{ duration: 0.3 }}
+        >
+          {children}
+          <footer>
+            <p>&copy; 2025 Baayno Website</p>
+          </footer>
+        </motion.div>
+      </AnimatePresence>
     </div>
   );
 }
+

--- a/components/SplashScreen.tsx
+++ b/components/SplashScreen.tsx
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+import { motion } from 'framer-motion';
+
+interface SplashScreenProps {
+  onFinish: () => void;
+}
+
+export default function SplashScreen({ onFinish }: SplashScreenProps) {
+  useEffect(() => {
+    const timer = setTimeout(onFinish, 2500);
+    return () => clearTimeout(timer);
+  }, [onFinish]);
+
+  return (
+    <motion.div
+      onClick={onFinish}
+      className="splash-screen"
+      initial={{ opacity: 1 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.5 }}
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: '#0b0b0b',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        zIndex: 9999,
+      }}
+    >
+      <motion.img
+        src="/logo.svg"
+        alt="Baayno Logo"
+        initial={{ opacity: 0, scale: 0.8 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ duration: 1 }}
+      />
+    </motion.div>
+  );
+}
+

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,9 +1,37 @@
 import type { AppProps } from 'next/app';
 import { appWithTranslation } from 'next-i18next';
+import { useEffect, useState } from 'react';
+import { AnimatePresence } from 'framer-motion';
+import SplashScreen from '@/components/SplashScreen';
 import '@/styles/globals.css';
 
 function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  const [showSplash, setShowSplash] = useState(true);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (sessionStorage.getItem('splashSeen')) {
+      setShowSplash(false);
+    }
+  }, []);
+
+  const handleFinish = () => {
+    if (typeof window !== 'undefined') {
+      sessionStorage.setItem('splashSeen', 'true');
+    }
+    setShowSplash(false);
+  };
+
+  return (
+    <AnimatePresence mode="wait">
+      {showSplash ? (
+        <SplashScreen key="splash" onFinish={handleFinish} />
+      ) : (
+        <Component key="page" {...pageProps} />
+      )}
+    </AnimatePresence>
+  );
 }
 
 export default appWithTranslation(App);
+


### PR DESCRIPTION
## Summary
- show animated logo on first load via new `SplashScreen`
- display splash screen before app content and cache completion in session storage
- add subtle route transitions using `AnimatePresence` in `Layout`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a87ba04100832e93eaa8068e32554e