### PR TITLE
Switch to SSR hosting

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy static site
+name: Build and deploy
 
 on:
   push:
@@ -7,34 +7,21 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Configure GitHub Pages
-        uses: actions/configure-pages@v5
       - run: npm ci
       - run: npm run build
-      - name: Disable Jekyll on Pages
-        run: |
-          mkdir -p out
-          touch out/.nojekyll
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          path: ./out
-      - id: deployment
-        uses: actions/deploy-pages@v4
+          name: next-standalone
+          path: |
+            .next/standalone
+            .next/static
+            public

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,6 @@
 import nextPWA from 'next-pwa';
 import nextI18NextConfig from './next-i18next.config.js';
 
-// Configure base path and asset prefix for GitHub Pages deployments
 const isProd = process.env.NODE_ENV === 'production';
 
 const withPWA = nextPWA({
@@ -14,14 +13,11 @@ const withPWA = nextPWA({
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  trailingSlash: true,
   images: {
-    unoptimized: true,
     domains: ['images.unsplash.com'],
   },
   i18n: nextI18NextConfig.i18n,
-  basePath: isProd ? '/Baayno-Website' : undefined,
-  assetPrefix: isProd ? '/Baayno-Website/' : undefined,
+  output: 'standalone',
 };
 
 export default withPWA(nextConfig);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "tsc && next build && next export",
+    "build": "tsc && next build",
     "start": "next start",
     "lint": "eslint",
     "test": "npm run lint && jest"


### PR DESCRIPTION
## Summary
- Drop static export by removing `next export` from the build script
- Simplify Next.js config for server hosting and output a standalone build
- Replace GitHub Pages workflow with a build artifact workflow

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a8ba9d993c832e8b78076c7f38806c