### PR TITLE
Handle missing mail configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,21 @@ The `pages/api` directory is mapped to `/api/*`. Files in this directory are tre
 
 This project uses [`next/font`](https://nextjs.org/docs/pages/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Environment Variables
+
+Email-based features require the following environment variables. Copy `.env.example` to `.env` and update with your SMTP credentials:
+
+```
+SMTP_HOST=
+SMTP_PORT=
+SMTP_USER=
+SMTP_PASS=
+SMTP_FROM=
+SMTP_TO=
+```
+
+If these values are missing in production, contact and quote forms will be disabled.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import styles from './ContactForm.module.css';
 
@@ -19,6 +19,21 @@ export default function ContactForm() {
   const [errors, setErrors] = useState<ErrorState>({});
   const [success, setSuccess] = useState('');
   const [submitError, setSubmitError] = useState('');
+  const [disabled, setDisabled] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/contact')
+      .then((res) => {
+        if (!res.ok) {
+          setDisabled(true);
+          setSubmitError('Email service not configured.');
+        }
+      })
+      .catch(() => {
+        setDisabled(true);
+        setSubmitError('Email service not configured.');
+      });
+  }, []);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -26,6 +41,7 @@ export default function ContactForm() {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>): Promise<void> => {
     e.preventDefault();
+    if (disabled) return;
     const newErrors: ErrorState = {};
     if (!form.name.trim()) newErrors.name = 'Name is required.';
     const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -144,7 +160,9 @@ export default function ContactForm() {
           )}
         </AnimatePresence>
       </div>
-      <button type="submit" className={styles.button} aria-label="Send message">Send</button>
+      <button type="submit" className={styles.button} aria-label="Send message" disabled={disabled}>
+        Send
+      </button>
       <AnimatePresence>
         {success && (
           <motion.span

--- a/components/QuoteForm.tsx
+++ b/components/QuoteForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import styles from './QuoteForm.module.css';
 
@@ -23,6 +23,21 @@ export default function QuoteForm() {
   const [errors, setErrors] = useState<ErrorState>({});
   const [success, setSuccess] = useState('');
   const [submitError, setSubmitError] = useState('');
+  const [disabled, setDisabled] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/quote')
+      .then((res) => {
+        if (!res.ok) {
+          setDisabled(true);
+          setSubmitError('Email service not configured.');
+        }
+      })
+      .catch(() => {
+        setDisabled(true);
+        setSubmitError('Email service not configured.');
+      });
+  }, []);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>): void => {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -30,6 +45,7 @@ export default function QuoteForm() {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>): Promise<void> => {
     e.preventDefault();
+    if (disabled) return;
     const newErrors: ErrorState = {};
     if (!form.name.trim()) newErrors.name = 'Name is required.';
     const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -198,7 +214,9 @@ export default function QuoteForm() {
               className={styles.textarea}
             ></textarea>
           </div>
-          <button type="submit" className={styles.button} aria-label="Submit quote request">Submit</button>
+          <button type="submit" className={styles.button} aria-label="Submit quote request" disabled={disabled}>
+            Submit
+          </button>
           <AnimatePresence>
             {success && (
               <motion.span

--- a/lib/mailer.ts
+++ b/lib/mailer.ts
@@ -9,9 +9,13 @@ type EnvVars = {
   SMTP_TO: string;
 };
 
+type ValidationResult =
+  | { env: EnvVars; error?: undefined; mock?: false }
+  | { env?: undefined; error: string; mock?: boolean };
+
 let transporter: nodemailer.Transporter | null = null;
 
-function validateEnv(): EnvVars {
+function validateEnv(): ValidationResult {
   const {
     SMTP_HOST,
     SMTP_PORT,
@@ -19,6 +23,8 @@ function validateEnv(): EnvVars {
     SMTP_PASS,
     SMTP_FROM,
     SMTP_TO,
+    NODE_ENV,
+    MOCK_TRANSPORT,
   } = process.env;
 
   const missing = [
@@ -30,32 +36,51 @@ function validateEnv(): EnvVars {
     'SMTP_TO',
   ].filter((key) => !process.env[key as keyof EnvVars]);
 
+  const isProd = NODE_ENV === 'production';
+  const useMock = MOCK_TRANSPORT === 'true' || !isProd;
+
+  if (missing.length > 0 && isProd && !useMock) {
+    return { error: `Missing required env vars: ${missing.join(', ')}` };
+  }
+
   if (missing.length > 0) {
-    throw new Error(`Missing required env vars: ${missing.join(', ')}`);
+    return { error: `Missing env vars: ${missing.join(', ')}`, mock: true };
   }
 
   return {
-    SMTP_HOST: SMTP_HOST!,
-    SMTP_PORT: SMTP_PORT!,
-    SMTP_USER: SMTP_USER!,
-    SMTP_PASS: SMTP_PASS!,
-    SMTP_FROM: SMTP_FROM!,
-    SMTP_TO: SMTP_TO!,
+    env: {
+      SMTP_HOST: SMTP_HOST!,
+      SMTP_PORT: SMTP_PORT!,
+      SMTP_USER: SMTP_USER!,
+      SMTP_PASS: SMTP_PASS!,
+      SMTP_FROM: SMTP_FROM!,
+      SMTP_TO: SMTP_TO!,
+    },
   };
 }
 
-export default function getTransporter(): nodemailer.Transporter {
+export default function getTransporter(): nodemailer.Transporter | null {
   if (!transporter) {
-    const env = validateEnv();
-    transporter = nodemailer.createTransport({
-      host: env.SMTP_HOST,
-      port: parseInt(env.SMTP_PORT, 10) || 587,
-      secure: parseInt(env.SMTP_PORT, 10) === 465,
-      auth: {
-        user: env.SMTP_USER,
-        pass: env.SMTP_PASS,
-      },
-    });
+    const result = validateEnv();
+    if ('error' in result) {
+      if (!result.mock) {
+        console.error(result.error);
+        return null;
+      }
+      transporter = nodemailer.createTransport({ jsonTransport: true });
+      console.warn(result.error);
+    } else {
+      const env = result.env;
+      transporter = nodemailer.createTransport({
+        host: env.SMTP_HOST,
+        port: parseInt(env.SMTP_PORT, 10) || 587,
+        secure: parseInt(env.SMTP_PORT, 10) === 465,
+        auth: {
+          user: env.SMTP_USER,
+          pass: env.SMTP_PASS,
+        },
+      });
+    }
   }
   return transporter;
 }

--- a/pages/api/quote.ts
+++ b/pages/api/quote.ts
@@ -2,8 +2,18 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import getTransporter from '../../lib/mailer';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
+  if (req.method === 'GET') {
+    const transporter = getTransporter();
+    if (!transporter) {
+      res.status(503).json({ error: 'Email service not configured.' });
+    } else {
+      res.status(200).json({ message: 'Email service configured.' });
+    }
+    return;
+  }
+
   if (req.method !== 'POST') {
-    res.setHeader('Allow', ['POST']);
+    res.setHeader('Allow', ['GET', 'POST']);
     res.status(405).json({ error: 'Method not allowed' });
     return;
   }
@@ -16,8 +26,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     notes: string;
   };
 
+  const transporter = getTransporter();
+  if (!transporter) {
+    res.status(503).json({ error: 'Email service not configured.' });
+    return;
+  }
+
   try {
-    const transporter = getTransporter();
     await transporter.sendMail({
       from: process.env.SMTP_FROM,
       to: process.env.SMTP_TO,

--- a/tests/QuoteForm.test.tsx
+++ b/tests/QuoteForm.test.tsx
@@ -4,6 +4,9 @@ import QuoteForm from '../components/QuoteForm';
 
 describe('QuoteForm', () => {
   it('shows validation errors for empty fields', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({ ok: true });
+    (global as any).fetch = mockFetch;
+
     render(<QuoteForm />);
     fireEvent.click(screen.getByRole('button', { name: /submit/i }));
     expect(await screen.findByText('Name is required.')).toBeInTheDocument();
@@ -13,6 +16,9 @@ describe('QuoteForm', () => {
   });
 
   it('shows error for invalid email', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({ ok: true });
+    (global as any).fetch = mockFetch;
+
     render(<QuoteForm />);
     fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'John Doe' } });
     fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'invalid' } });


### PR DESCRIPTION
## Summary
- document SMTP environment variables and note form disablement when unconfigured
- add safe mailer validation with optional mock transport
- disable contact and quote forms when email service is missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a96e95132c832e89eb08bc9c4549c4