### PR TITLE
Prefix data and API requests with router basePath

### DIFF
--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
 import { motion, AnimatePresence } from 'framer-motion';
 import styles from './ContactForm.module.css';
 
@@ -20,9 +21,10 @@ export default function ContactForm() {
   const [success, setSuccess] = useState('');
   const [submitError, setSubmitError] = useState('');
   const [disabled, setDisabled] = useState(false);
+  const router = useRouter();
 
   useEffect(() => {
-    fetch('/api/contact')
+    fetch(`${router.basePath}/api/contact`)
       .then((res) => {
         if (!res.ok) {
           setDisabled(true);
@@ -33,7 +35,7 @@ export default function ContactForm() {
         setDisabled(true);
         setSubmitError('Email service not configured.');
       });
-  }, []);
+  }, [router.basePath]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -51,7 +53,7 @@ export default function ContactForm() {
     setErrors(newErrors);
     if (Object.keys(newErrors).length === 0) {
       try {
-        const res = await fetch('/api/contact', {
+        const res = await fetch(`${router.basePath}/api/contact`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(form),

--- a/components/QuoteForm.tsx
+++ b/components/QuoteForm.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
 import { motion, AnimatePresence } from 'framer-motion';
 import styles from './QuoteForm.module.css';
 
@@ -24,9 +25,10 @@ export default function QuoteForm() {
   const [success, setSuccess] = useState('');
   const [submitError, setSubmitError] = useState('');
   const [disabled, setDisabled] = useState(false);
+  const router = useRouter();
 
   useEffect(() => {
-    fetch('/api/quote')
+    fetch(`${router.basePath}/api/quote`)
       .then((res) => {
         if (!res.ok) {
           setDisabled(true);
@@ -37,7 +39,7 @@ export default function QuoteForm() {
         setDisabled(true);
         setSubmitError('Email service not configured.');
       });
-  }, []);
+  }, [router.basePath]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>): void => {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -56,7 +58,7 @@ export default function QuoteForm() {
     setErrors(newErrors);
     if (Object.keys(newErrors).length === 0) {
       try {
-        const res = await fetch('/api/quote', {
+        const res = await fetch(`${router.basePath}/api/quote`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(form),

--- a/components/Services.tsx
+++ b/components/Services.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
 import styles from './Services.module.css';
 import cardStyles from './Card.module.css';
 import { FaBook, FaBookOpen, FaTools, FaStar, FaFlask, FaIndustry } from 'react-icons/fa';
@@ -13,13 +14,14 @@ interface Service {
 
 export default function Services() {
   const [services, setServices] = useState<Service[]>([]);
+  const router = useRouter();
 
   useEffect(() => {
-    fetch('/data/company.json')
+    fetch(`${router.basePath}/data/company.json`)
       .then(res => res.json())
       .then((data: { services?: Service[] }) => setServices(data.services || []))
       .catch(() => {});
-  }, []);
+  }, [router.basePath]);
 
   return (
     <section id="services" className={`container ${styles.services}`}>

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
 import Layout from '@/components/Layout';
 import ContactForm from '@/components/ContactForm';
 import SEO from '@/components/SEO';
@@ -10,13 +11,14 @@ interface CompanyInfo {
 
 export default function ContactPage() {
   const [info, setInfo] = useState<CompanyInfo>({ address: '', phones: [] });
+  const router = useRouter();
 
   useEffect(() => {
-    fetch('/data/company.json')
+    fetch(`${router.basePath}/data/company.json`)
       .then(res => res.json())
       .then((data: CompanyInfo) => setInfo({ address: data.address, phones: data.phones || [] }))
       .catch(() => {});
-  }, []);
+  }, [router.basePath]);
 
   return (
     <Layout>

--- a/tests/ContactForm.test.tsx
+++ b/tests/ContactForm.test.tsx
@@ -1,8 +1,18 @@
 /* eslint-env jest */
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import ContactForm from '../components/ContactForm';
+import { useRouter } from 'next/router';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
 
 describe('ContactForm', () => {
+  const basePath = '/base';
+
+  beforeEach(() => {
+    (useRouter as jest.Mock).mockReturnValue({ basePath });
+  });
   it('shows validation errors for empty and invalid input', async () => {
     const mockFetch = jest.fn().mockResolvedValue({ ok: true });
     (global as any).fetch = mockFetch;
@@ -13,6 +23,7 @@ describe('ContactForm', () => {
     expect(await screen.findByText('Name is required.')).toBeInTheDocument();
     expect(await screen.findByText('Email is required.')).toBeInTheDocument();
     expect(await screen.findByText('Message is required.')).toBeInTheDocument();
+    expect(mockFetch).toHaveBeenCalledWith(`${basePath}/api/contact`);
     expect(mockFetch).toHaveBeenCalledTimes(1);
 
     fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'John Doe' } });
@@ -40,7 +51,7 @@ describe('ContactForm', () => {
     await waitFor(() =>
       expect(mockFetch).toHaveBeenNthCalledWith(
         2,
-        '/api/contact',
+        `${basePath}/api/contact`,
         expect.objectContaining({ method: 'POST' })
       )
     );

--- a/tests/QuoteForm.test.tsx
+++ b/tests/QuoteForm.test.tsx
@@ -1,8 +1,19 @@
 /* eslint-env jest */
 import { render, screen, fireEvent } from '@testing-library/react';
 import QuoteForm from '../components/QuoteForm';
+import { useRouter } from 'next/router';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
 
 describe('QuoteForm', () => {
+  const basePath = '/base';
+
+  beforeEach(() => {
+    (useRouter as jest.Mock).mockReturnValue({ basePath });
+  });
+
   it('shows validation errors for empty fields', async () => {
     const mockFetch = jest.fn().mockResolvedValue({ ok: true });
     (global as any).fetch = mockFetch;
@@ -13,6 +24,8 @@ describe('QuoteForm', () => {
     expect(await screen.findByText('Email is required.')).toBeInTheDocument();
     expect(await screen.findByText('Book type is required.')).toBeInTheDocument();
     expect(await screen.findByText('Enter a valid quantity.')).toBeInTheDocument();
+    expect(mockFetch).toHaveBeenCalledWith(`${basePath}/api/quote`);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
   it('shows error for invalid email', async () => {
@@ -26,5 +39,7 @@ describe('QuoteForm', () => {
     fireEvent.change(screen.getByLabelText(/quantity/i), { target: { value: '1' } });
     fireEvent.click(screen.getByRole('button', { name: /submit/i }));
     expect(await screen.findByText('Enter a valid email.')).toBeInTheDocument();
+    expect(mockFetch).toHaveBeenCalledWith(`${basePath}/api/quote`);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- include `router.basePath` when fetching company data in contact page and services component
- prefix contact and quote form API calls with `router.basePath`
- adjust unit tests to mock `useRouter` and expect base path URLs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a984b65de4832ea2fe58933a995544