### PR TITLE
Use BASE_PATH to prefix manifest and service worker

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,10 +1,12 @@
 import { Html, Head, Main, NextScript } from 'next/document';
 
 export default function Document() {
+  const basePath = process.env.BASE_PATH || '';
+
   return (
     <Html lang="en">
       <Head>
-        <link rel="manifest" href="/manifest.json" />
+        <link rel="manifest" href={`${basePath}/manifest.json`} />
         <meta name="theme-color" content="#ffffff" />
       </Head>
       <body>
@@ -15,7 +17,7 @@ export default function Document() {
             __html: `
               if ('serviceWorker' in navigator) {
                 window.addEventListener('load', () => {
-                  navigator.serviceWorker.register('sw.js');
+                  navigator.serviceWorker.register('${basePath}/sw.js');
                 });
               }
             `,


### PR DESCRIPTION
## Summary
- derive `basePath` from `BASE_PATH` env var
- prefix manifest link and service worker registration with `basePath`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a994efbb04832e8311592d8ac235b5