### PR TITLE
Add animated loader to splash screen

### DIFF
--- a/components/Loader.module.css
+++ b/components/Loader.module.css
@@ -1,0 +1,43 @@
+.loader {
+  width: 48px;
+  height: 48px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(2, 1fr);
+  gap: 4px;
+}
+
+.loader span {
+  background: #fff;
+  opacity: 0.2;
+  animation: keyframes-blink 1.4s infinite both;
+}
+
+.loader span:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.loader span:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+.loader span:nth-child(4) {
+  animation-delay: 0.6s;
+}
+
+.loader span:nth-child(5) {
+  animation-delay: 0.8s;
+}
+
+.loader span:nth-child(6) {
+  animation-delay: 1s;
+}
+
+@keyframes keyframes-blink {
+  0%, 100% {
+    opacity: 0.2;
+  }
+  50% {
+    opacity: 1;
+  }
+}

--- a/components/Loader.tsx
+++ b/components/Loader.tsx
@@ -1,0 +1,14 @@
+import styles from './Loader.module.css';
+
+export default function Loader() {
+  return (
+    <div className={styles.loader}>
+      <span />
+      <span />
+      <span />
+      <span />
+      <span />
+      <span />
+    </div>
+  );
+}

--- a/components/SplashScreen.tsx
+++ b/components/SplashScreen.tsx
@@ -1,13 +1,12 @@
 import { useEffect } from 'react';
 import { motion } from 'framer-motion';
-import { useRouter } from 'next/router';
+import Loader from './Loader';
 
 interface SplashScreenProps {
   onFinish: () => void;
 }
 
 export default function SplashScreen({ onFinish }: SplashScreenProps) {
-  const router = useRouter();
   useEffect(() => {
     const timer = setTimeout(onFinish, 2500);
     return () => clearTimeout(timer);
@@ -34,13 +33,7 @@ export default function SplashScreen({ onFinish }: SplashScreenProps) {
         zIndex: 9999,
       }}
     >
-      <motion.img
-        src={`${router.basePath}/logo.svg`}
-        alt="Baayno Logo"
-        initial={{ opacity: 0, scale: 0.8 }}
-        animate={{ opacity: 1, scale: 1 }}
-        transition={{ duration: 1 }}
-      />
+      <Loader />
     </motion.div>
   );
 }


### PR DESCRIPTION
## Summary
- add grid-based Loader component with blink animation
- use Loader in SplashScreen instead of static logo

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a9985ea56c832e9ec3dd4c890f4e92