### PR TITLE
Add animated loader on navigation

### DIFF
--- a/components/Loader.module.css
+++ b/components/Loader.module.css
@@ -1,0 +1,52 @@
+.loader {
+  --color: #a5a5b0;
+  --size: 70px;
+  width: var(--size);
+  height: var(--size);
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 5px;
+}
+
+.loader span {
+  width: 100%;
+  height: 100%;
+  background-color: var(--color);
+  animation: keyframes-blink 0.6s alternate infinite linear;
+}
+
+.loader span:nth-child(1) {
+  animation-delay: 0ms;
+}
+
+.loader span:nth-child(2) {
+  animation-delay: 200ms;
+}
+
+.loader span:nth-child(3) {
+  animation-delay: 300ms;
+}
+
+.loader span:nth-child(4) {
+  animation-delay: 400ms;
+}
+
+.loader span:nth-child(5) {
+  animation-delay: 500ms;
+}
+
+.loader span:nth-child(6) {
+  animation-delay: 600ms;
+}
+
+@keyframes keyframes-blink {
+  0% {
+    opacity: 0.3;
+    transform: scale(0.5) rotate(5deg);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}

--- a/components/Loader.tsx
+++ b/components/Loader.tsx
@@ -1,0 +1,14 @@
+import styles from './Loader.module.css';
+
+export default function Loader() {
+  return (
+    <div className={styles.loader}>
+      <span />
+      <span />
+      <span />
+      <span />
+      <span />
+      <span />
+    </div>
+  );
+}

--- a/components/SplashScreen.tsx
+++ b/components/SplashScreen.tsx
@@ -1,21 +1,19 @@
 import { useEffect } from 'react';
 import { motion } from 'framer-motion';
-import { useRouter } from 'next/router';
+import Loader from './Loader';
 
 interface SplashScreenProps {
   onFinish: () => void;
 }
 
 export default function SplashScreen({ onFinish }: SplashScreenProps) {
-  const router = useRouter();
   useEffect(() => {
-    const timer = setTimeout(onFinish, 2500);
+    const timer = setTimeout(onFinish, 3000);
     return () => clearTimeout(timer);
   }, [onFinish]);
 
   return (
     <motion.div
-      onClick={onFinish}
       className="splash-screen"
       initial={{ opacity: 1 }}
       animate={{ opacity: 1 }}
@@ -34,13 +32,7 @@ export default function SplashScreen({ onFinish }: SplashScreenProps) {
         zIndex: 9999,
       }}
     >
-      <motion.img
-        src={`${router.basePath}/logo.svg`}
-        alt="Baayno Logo"
-        initial={{ opacity: 0, scale: 0.8 }}
-        animate={{ opacity: 1, scale: 1 }}
-        transition={{ duration: 1 }}
-      />
+      <Loader />
     </motion.div>
   );
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,23 +2,23 @@ import type { AppProps } from 'next/app';
 import { appWithTranslation } from 'next-i18next';
 import { useEffect, useState } from 'react';
 import { AnimatePresence } from 'framer-motion';
+import { useRouter } from 'next/router';
 import SplashScreen from '@/components/SplashScreen';
 import '@/styles/globals.css';
 
 function App({ Component, pageProps }: AppProps) {
+  const router = useRouter();
   const [showSplash, setShowSplash] = useState(true);
 
   useEffect(() => {
-    if (typeof window === 'undefined') return;
-    if (sessionStorage.getItem('splashSeen')) {
-      setShowSplash(false);
-    }
-  }, []);
+    const handleStart = () => setShowSplash(true);
+    router.events.on('routeChangeStart', handleStart);
+    return () => {
+      router.events.off('routeChangeStart', handleStart);
+    };
+  }, [router.events]);
 
   const handleFinish = () => {
-    if (typeof window !== 'undefined') {
-      sessionStorage.setItem('splashSeen', 'true');
-    }
     setShowSplash(false);
   };
 
@@ -27,7 +27,7 @@ function App({ Component, pageProps }: AppProps) {
       {showSplash ? (
         <SplashScreen key="splash" onFinish={handleFinish} />
       ) : (
-        <Component key="page" {...pageProps} />
+        <Component key={router.asPath} {...pageProps} />
       )}
     </AnimatePresence>
   );


### PR DESCRIPTION
## Summary
- implement grid-based loader animation using Uiverse.io CSS
- show loader for 3 seconds on initial load and every route change

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a9985ea56c832e9ec3dd4c890f4e92