### PR TITLE
Align splash and hero animations

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -44,9 +44,9 @@ export default function Hero() {
         <BookAnimation />
         <motion.h1
           className="heading-font"
-          initial={{ opacity: 0, y: -20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6 }}
+          initial={{ opacity: 0, scale: 0.95 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.6, ease: 'easeInOut' }}
         >
           Handcrafted Bookbinding
         </motion.h1>
@@ -55,9 +55,9 @@ export default function Hero() {
           className="btn btn-primary"
           onClick={scrollToQuote}
           aria-label="Request a Quote"
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.3, duration: 0.6 }}
+          initial={{ opacity: 0, scale: 0.95 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ delay: 0.3, duration: 0.6, ease: 'easeInOut' }}
         >
           Request a Quote
         </motion.button>

--- a/components/SplashScreen.tsx
+++ b/components/SplashScreen.tsx
@@ -15,10 +15,10 @@ export default function SplashScreen({ onFinish }: SplashScreenProps) {
   return (
     <motion.div
       className="splash-screen"
-      initial={{ opacity: 1 }}
-      animate={{ opacity: 1 }}
-      exit={{ opacity: 0 }}
-      transition={{ duration: 0.5 }}
+      initial={{ opacity: 1, scale: 1 }}
+      animate={{ opacity: 1, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.95 }}
+      transition={{ duration: 0.6, ease: 'easeInOut' }}
       style={{
         position: 'fixed',
         top: 0,


### PR DESCRIPTION
## Summary
- Sync splash exit and hero entry animations with matching 0.6s easeInOut transitions
- Use consistent fade/scale effects on hero heading and call-to-action button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a99de6d7b0832e8fc61d3c2fbeaaab