### PR TITLE
Add GitHub Actions workflow for static deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ name: Build and deploy
 on:
   push:
     branches: ["main"]
-  workflow_dispatch:
 
 permissions:
   contents: write
@@ -11,8 +10,6 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      BASE_PATH: '/Baayno-Website'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -20,6 +17,7 @@ jobs:
           node-version: 20
       - run: npm ci
       - run: npm run build
+      - run: npx next export
       - uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- build and export the Next.js app on pushes to main
- deploy the exported `/out` directory to the `gh-pages` branch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a9a2bc5d60832e9d7ae9f5876ebdc5