### PR TITLE
Remove manual export from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,6 @@ jobs:
           node-version: 20
       - run: npm ci
       - run: npm run build
-      - run: npx next export
       - uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- remove redundant `npx next export` from deploy workflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a9a92e1f0c832eb626d48c22e7285c