### PR TITLE
feat: update accent color

### DIFF
--- a/components/ContactForm.module.css
+++ b/components/ContactForm.module.css
@@ -69,6 +69,6 @@
 
 .successMessage {
   display: block;
-  color: var(--color-gold);
+  color: var(--accent);
   margin-top: 1em;
 }

--- a/components/QuoteForm.module.css
+++ b/components/QuoteForm.module.css
@@ -73,6 +73,6 @@
 
 .successMessage {
   display: block;
-  color: var(--color-gold);
+  color: var(--accent);
   margin-top: 1em;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,18 +1,18 @@
 html[data-theme="light"] {
   --background: #ffffff;
   --foreground: #000000;
-  --accent: #d61f26;
-  --accent-hover: #b3191f;
-  --accent-active: #8f1419;
+  --accent: #4a90e2;
+  --accent-hover: #3a78c2;
+  --accent-active: #2a60a2;
   color-scheme: light;
 }
 
 html[data-theme="dark"] {
   --background: #1a1a1a;
   --foreground: #d61f26;
-  --accent: #d61f26;
-  --accent-hover: #b3191f;
-  --accent-active: #8f1419;
+  --accent: #4a90e2;
+  --accent-hover: #3a78c2;
+  --accent-active: #2a60a2;
   color-scheme: dark;
 }
 
@@ -68,7 +68,6 @@ html[data-theme="dark"] {
     --color-black: #0b0b0b;
     --color-white: #ffffff;
     --color-red: #d61f26;
-    --color-gold: #c9a227;
     --font-body: 'Open Sans', sans-serif;
     --font-heading: 'caecilia_lt_std55_roman', serif;
     --fw-normal: 400;
@@ -91,7 +90,7 @@ html[data-theme="dark"] {
 
 .gradient-bg {
     min-height: 100vh;
-    background: linear-gradient(-45deg, var(--color-gold), var(--accent));
+    background: linear-gradient(-45deg, var(--accent), var(--accent-hover));
     background-size: 400% 400%;
     animation: gold-accent-gradient 15s ease infinite;
 }


### PR DESCRIPTION
## Summary
- switch site accent to cleaner blue tone
- remove legacy gold variable and update gradient background
- align form success messages with accent color

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a9b392e994832eb942d3b62f5dc7bc