### PR TITLE
Show app beneath fading splash overlay

### DIFF
--- a/components/SplashScreen.tsx
+++ b/components/SplashScreen.tsx
@@ -1,39 +1,42 @@
 import { useEffect } from 'react';
-import { motion } from 'framer-motion';
 import Loader from './Loader';
 
 interface SplashScreenProps {
-  onFinish: () => void;
+  onFinish?: () => void;
+  timeout?: number;
 }
 
-export default function SplashScreen({ onFinish }: SplashScreenProps) {
+export default function SplashScreen({ onFinish, timeout = 3000 }: SplashScreenProps) {
   useEffect(() => {
-    const timer = setTimeout(onFinish, 3000);
+    if (!onFinish) return;
+    const timer = setTimeout(onFinish, timeout);
     return () => clearTimeout(timer);
-  }, [onFinish]);
+  }, [onFinish, timeout]);
 
   return (
-    <motion.div
-      className="splash-screen"
-      initial={{ opacity: 1, scale: 1 }}
-      animate={{ opacity: 1, scale: 1 }}
-      exit={{ opacity: 0, scale: 0.95 }}
-      transition={{ duration: 0.6, ease: 'easeInOut' }}
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        backgroundColor: '#0b0b0b',
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        zIndex: 9999,
-      }}
-    >
+    <div className="splash-screen">
       <Loader />
-    </motion.div>
+      <style jsx>{`
+        .splash-screen {
+          position: fixed;
+          inset: 0;
+          background-color: #0b0b0b;
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          z-index: 9999;
+          animation: fadeOut 0.6s ease ${timeout}ms forwards;
+        }
+
+        @keyframes fadeOut {
+          to {
+            opacity: 0;
+            visibility: hidden;
+            pointer-events: none;
+          }
+        }
+      `}</style>
+    </div>
   );
 }
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,7 +1,6 @@
 import type { AppProps } from 'next/app';
 import { appWithTranslation } from 'next-i18next';
 import { useEffect, useState } from 'react';
-import { AnimatePresence } from 'framer-motion';
 import { useRouter } from 'next/router';
 import SplashScreen from '@/components/SplashScreen';
 import '@/styles/globals.css';
@@ -23,13 +22,10 @@ function App({ Component, pageProps }: AppProps) {
   };
 
   return (
-    <AnimatePresence mode="wait">
-      {showSplash ? (
-        <SplashScreen key="splash" onFinish={handleFinish} />
-      ) : (
-        <Component key={router.asPath} {...pageProps} />
-      )}
-    </AnimatePresence>
+    <>
+      <Component key={router.asPath} {...pageProps} />
+      {showSplash && <SplashScreen onFinish={handleFinish} />}
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- render pages even while splash screen is visible
- fade splash screen overlay and hide it after timeout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a9b9af7a40832e9d073350dd870e4b