### PR TITLE
feat: use server runtime

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -17,7 +17,6 @@ const nextConfig = {
     unoptimized: true,
     domains: ['images.unsplash.com'],
   },
-  output: 'export',
   basePath,
   assetPrefix: basePath ? `${basePath}/` : undefined,
 };


### PR DESCRIPTION
## Summary
- allow server runtime by removing `output: 'export'`

## Testing
- `npm test`
- `npm run build`
- `curl -i http://localhost:3000/api/contact`
- `curl -i http://localhost:3000/api/quote`


------
https://chatgpt.com/codex/tasks/task_b_68a9c4675748832e8e45aff4c78821eb