### PR TITLE
Add loading state and error handling to Services

### DIFF
--- a/components/Services.tsx
+++ b/components/Services.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import styles from './Services.module.css';
 import cardStyles from './Card.module.css';
+import Loader from './Loader';
 import { FaBook, FaBookOpen, FaTools, FaStar, FaFlask, FaIndustry } from 'react-icons/fa';
 
 const icons = { FaBook, FaBookOpen, FaTools, FaStar, FaFlask, FaIndustry };
@@ -14,33 +15,45 @@ interface Service {
 
 export default function Services() {
   const [services, setServices] = useState<Service[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
   const router = useRouter();
 
   useEffect(() => {
     fetch(`${router.basePath}/data/company.json`)
       .then(res => res.json())
       .then((data: { services?: Service[] }) => setServices(data.services || []))
-      .catch(() => {});
+      .catch((err) => {
+        console.error('Failed to load services:', err);
+        setError('Failed to load services.');
+      })
+      .finally(() => setLoading(false));
   }, [router.basePath]);
 
   return (
     <section id="services" className={`container ${styles.services}`}>
       <h2 className="heading-font">Services</h2>
       <div className={styles.serviceGrid}>
-        {services.map((service, idx) => {
-          const Icon = service.icon ? icons[service.icon] : null;
-          return (
-            <article key={idx} className={cardStyles.card}>
-              {Icon && (
-                <div className={cardStyles.icon}>
-                  <Icon />
-                </div>
-              )}
-              <h3>{service.title}</h3>
-              <p>{service.description}</p>
-            </article>
-          );
-        })}
+        {loading ? (
+          <Loader />
+        ) : error ? (
+          <p>{error}</p>
+        ) : (
+          services.map((service, idx) => {
+            const Icon = service.icon ? icons[service.icon] : null;
+            return (
+              <article key={idx} className={cardStyles.card}>
+                {Icon && (
+                  <div className={cardStyles.icon}>
+                    <Icon />
+                  </div>
+                )}
+                <h3>{service.title}</h3>
+                <p>{service.description}</p>
+              </article>
+            );
+          })
+        )}
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- log errors and show fallback message when services fail to load
- display loader while fetching service data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a9c549b4ec832eb722989a3acf8983