### PR TITLE
Default base path for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,8 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build   # outputs ./out
+        env:
+          BASE_PATH: '/Baayno-Website'
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./out

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,7 @@
 import nextPWA from 'next-pwa';
 
 const isProd = process.env.NODE_ENV === 'production';
-const basePath = process.env.BASE_PATH || '';
+const basePath = process.env.BASE_PATH ?? '/Baayno-Website';
 
 const withPWA = nextPWA({
   dest: 'public',


### PR DESCRIPTION
## Summary
- default to `/Baayno-Website` when `BASE_PATH` is unset so GitHub Pages assets resolve correctly
- export `BASE_PATH` in workflow prior to building static pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68aad1c0a7e8832ebbcd2894cc757115