### PR TITLE
feat: switch site to beige glass theme

### DIFF
--- a/components/ContactForm.module.css
+++ b/components/ContactForm.module.css
@@ -28,7 +28,7 @@
 .textarea:focus,
 .select:focus {
   border-color: var(--accent);
-  box-shadow: 0 0 0 2px rgba(74, 144, 226, 0.2);
+  box-shadow: 0 0 0 2px rgba(231, 224, 213, 0.2);
   outline: none;
 }
 
@@ -38,27 +38,6 @@
   border-color: var(--color-red);
 }
 
-.button {
-  padding: var(--btn-padding);
-  font-size: 1em;
-  background: var(--accent);
-  color: var(--color-white);
-  border: none;
-  border-radius: var(--radius);
-  cursor: pointer;
-  transition: background 0.3s, transform 0.3s;
-}
-
-.button:hover,
-.button:focus {
-  background: var(--accent-hover);
-  transform: translateY(-2px);
-}
-
-.button:active {
-  background: var(--accent-active);
-  transform: translateY(0);
-}
 
 .errorMessage {
   display: block;

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -162,7 +162,7 @@ export default function ContactForm() {
           )}
         </AnimatePresence>
       </div>
-      <button type="submit" className={styles.button} aria-label="Send message" disabled={disabled}>
+      <button type="submit" className="btn btn-primary" aria-label="Send message" disabled={disabled}>
         Send
       </button>
       <AnimatePresence>

--- a/components/QuoteForm.module.css
+++ b/components/QuoteForm.module.css
@@ -32,7 +32,7 @@
 .textarea:focus,
 .select:focus {
   border-color: var(--accent);
-  box-shadow: 0 0 0 2px rgba(74, 144, 226, 0.2);
+  box-shadow: 0 0 0 2px rgba(231, 224, 213, 0.2);
   outline: none;
 }
 
@@ -42,27 +42,6 @@
   border-color: var(--color-red);
 }
 
-.button {
-  padding: var(--btn-padding);
-  font-size: 1em;
-  background: var(--accent);
-  color: var(--color-white);
-  border: none;
-  border-radius: var(--radius);
-  cursor: pointer;
-  transition: background 0.3s, transform 0.3s;
-}
-
-.button:hover,
-.button:focus {
-  background: var(--accent-hover);
-  transform: translateY(-2px);
-}
-
-.button:active {
-  background: var(--accent-active);
-  transform: translateY(0);
-}
 
 .errorMessage {
   display: block;

--- a/components/QuoteForm.tsx
+++ b/components/QuoteForm.tsx
@@ -216,7 +216,7 @@ export default function QuoteForm() {
               className={styles.textarea}
             ></textarea>
           </div>
-          <button type="submit" className={styles.button} aria-label="Submit quote request" disabled={disabled}>
+          <button type="submit" className="btn btn-primary" aria-label="Submit quote request" disabled={disabled}>
             Submit
           </button>
           <AnimatePresence>

--- a/components/hero/HeroHeritageClean.module.css
+++ b/components/hero/HeroHeritageClean.module.css
@@ -36,3 +36,8 @@
   padding: 2rem;
   color: var(--color-white);
 }
+
+.title {
+  font-family: var(--font-heading);
+  font-weight: var(--fw-bold);
+}

--- a/components/hero/HeroHeritageClean.tsx
+++ b/components/hero/HeroHeritageClean.tsx
@@ -21,7 +21,7 @@ export default function HeroHeritageClean() {
       <div className={styles.content}>
         <BookLogo />
         <motion.h1
-          className="heading-font"
+          className={styles.title}
           initial={{ opacity: 0, scale: 0.95 }}
           animate={{ opacity: 1, scale: 1 }}
           transition={{ duration: 0.6, ease: 'easeInOut' }}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,18 +1,18 @@
 html[data-theme="light"] {
   --background: #ffffff;
   --foreground: #000000;
-  --accent: #4a90e2;
-  --accent-hover: #3a78c2;
-  --accent-active: #2a60a2;
+  --accent: #e7e0d5;
+  --accent-hover: #d9cfbe;
+  --accent-active: #cbc0b1;
   color-scheme: light;
 }
 
 html[data-theme="dark"] {
   --background: #1a1a1a;
   --foreground: #d61f26;
-  --accent: #4a90e2;
-  --accent-hover: #3a78c2;
-  --accent-active: #2a60a2;
+  --accent: #e7e0d5;
+  --accent-hover: #d9cfbe;
+  --accent-active: #cbc0b1;
   color-scheme: dark;
 }
 
@@ -173,52 +173,46 @@ body {
   }
 
 /* Buttons */
-  button {
-      padding: var(--btn-padding);
-      font-size: 1em;
-      background: var(--accent);
-      color: var(--color-white);
-      border: none;
-      border-radius: var(--radius);
-      cursor: pointer;
-      transition: all 0.3s ease;
-  }
-
-  button:hover,
-  button:focus {
-      background: var(--accent-hover);
-      transform: translateY(-2px);
-  }
-
-  button:active {
-      background: var(--accent-active);
-      transform: translateY(0);
-  }
-
+button,
 .btn {
-    display: inline-block;
     padding: var(--btn-padding);
-    border-radius: var(--radius);
-    border: 2px solid transparent;
+    font-size: 1em;
+    border-radius: 9999px;
+    border: 1px solid rgba(231, 224, 213, 0.4);
+    background: rgba(231, 224, 213, 0.2);
+    color: var(--color-black);
+    backdrop-filter: blur(10px);
     cursor: pointer;
-    transition: background 0.3s, color 0.3s, transform 0.3s;
+    transition: background 0.3s, transform 0.3s;
 }
 
-  .btn-primary {
-      background: var(--accent);
-      color: var(--color-white);
-  }
+button:hover,
+button:focus,
+.btn:hover,
+.btn:focus {
+    background: rgba(231, 224, 213, 0.4);
+    transform: translateY(-2px);
+}
 
-  .btn-primary:hover,
-  .btn-primary:focus {
-      background: var(--accent-hover);
-      transform: translateY(-2px);
-  }
+button:active,
+.btn:active {
+    background: rgba(231, 224, 213, 0.6);
+    transform: translateY(0);
+}
 
-  .btn-primary:active {
-      background: var(--accent-active);
-      transform: translateY(0);
-  }
+.btn-primary {
+    background: rgba(231, 224, 213, 0.6);
+    border-color: rgba(231, 224, 213, 0.6);
+}
+
+.btn-primary:hover,
+.btn-primary:focus {
+    background: rgba(231, 224, 213, 0.8);
+}
+
+.btn-primary:active {
+    background: rgba(231, 224, 213, 1);
+}
 
 footer {
     text-align: center;


### PR DESCRIPTION
## Summary
- restyle theme variables and gradient for new beige palette
- implement reusable rounded glass buttons and update forms
- move hero heading to module for consistent styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ac6ecc67b0832eb42c201fca426c3e