### PR TITLE
Add dedicated About and Quote pages

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -45,6 +45,11 @@ export default function Navbar() {
             </Link>
           </li>
           <li>
+            <Link href="/about" onClick={close} className={isActive('/about') ? styles.active : ''}>
+              {t('about')}
+            </Link>
+          </li>
+          <li>
             <Link href="/services" onClick={close} className={isActive('/services') ? styles.active : ''}>
               {t('services')}
             </Link>
@@ -62,6 +67,11 @@ export default function Navbar() {
           <li>
             <Link href="/contact" onClick={close} className={isActive('/contact') ? styles.active : ''}>
               {t('contact')}
+            </Link>
+          </li>
+          <li>
+            <Link href="/quote" onClick={close} className={isActive('/quote') ? styles.active : ''}>
+              {t('quote')}
             </Link>
           </li>
         </ul>

--- a/components/hero/HeroHeritageClean.tsx
+++ b/components/hero/HeroHeritageClean.tsx
@@ -1,13 +1,13 @@
 import { motion } from 'framer-motion';
+import { useRouter } from 'next/router';
 import BookLogo from './BookLogo';
 import MediaLoop from './MediaLoop';
 import styles from './HeroHeritageClean.module.css';
 
 export default function HeroHeritageClean() {
-  const scrollToQuote = (): void => {
-    if (typeof document !== 'undefined') {
-      document.getElementById('quote')?.scrollIntoView({ behavior: 'smooth' });
-    }
+  const router = useRouter();
+  const goToQuote = (): void => {
+    router.push('/quote').catch(() => {});
   };
 
   return (
@@ -31,7 +31,7 @@ export default function HeroHeritageClean() {
         <p>Precision Bookbinding &amp; Finishing</p>
         <motion.button
           className="btn btn-primary"
-          onClick={scrollToQuote}
+          onClick={goToQuote}
           aria-label="Request a Quote"
           initial={{ opacity: 0, scale: 0.95 }}
           animate={{ opacity: 1, scale: 1 }}

--- a/locales/ar/common.json
+++ b/locales/ar/common.json
@@ -1,9 +1,11 @@
 {
   "home": "الرئيسية",
+  "about": "حول",
   "services": "الخدمات",
   "portfolio": "المعرض",
   "blog": "المدونة",
   "contact": "اتصال",
+  "quote": "عرض سعر",
   "themeDark": "داكن",
   "themeLight": "فاتح",
   "seoTitle": "باينو — تجليد وإنهاء الكتب",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -1,9 +1,11 @@
 {
   "home": "Home",
+  "about": "About",
   "services": "Services",
   "portfolio": "Portfolio",
   "blog": "Blog",
   "contact": "Contact",
+  "quote": "Quote",
   "themeDark": "Dark",
   "themeLight": "Light",
   "seoTitle": "Baayno — Bookbinding & Finishing",

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -1,9 +1,11 @@
 {
   "home": "Accueil",
+  "about": "À propos",
   "services": "Services",
   "portfolio": "Portfolio",
   "blog": "Blog",
   "contact": "Contact",
+  "quote": "Devis",
   "themeDark": "Sombre",
   "themeLight": "Clair",
   "seoTitle": "Baayno — Reliure et finition de livres",

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,0 +1,12 @@
+import Layout from '@/components/Layout';
+import About from '@/components/About';
+import SEO from '@/components/SEO';
+
+export default function AboutPage() {
+  return (
+    <Layout>
+      <SEO title="About - Baayno" canonical="https://www.baayno.com/about" />
+      <About />
+    </Layout>
+  );
+}

--- a/pages/quote.tsx
+++ b/pages/quote.tsx
@@ -1,0 +1,12 @@
+import Layout from '@/components/Layout';
+import QuoteForm from '@/components/QuoteForm';
+import SEO from '@/components/SEO';
+
+export default function QuotePage() {
+  return (
+    <Layout>
+      <SEO title="Request a Quote - Baayno" canonical="https://www.baayno.com/quote" />
+      <QuoteForm />
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- link hero CTA to a new `/quote` route and add `/about` and `/quote` links to the navbar
- translate new navigation labels and wire pages with existing About and QuoteForm components

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ac75592318832e89e5bf1423fa60fe