### PR TITLE
Wrap layout content in main container

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -14,7 +14,9 @@ export default function Layout({ children }: LayoutProps) {
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
-    const sections = document.querySelectorAll('section');
+    const main = document.querySelector('main');
+    if (!main) return;
+    const sections = main.querySelectorAll('section');
     const observer = new IntersectionObserver(
       entries => {
         entries.forEach(entry => {
@@ -47,10 +49,12 @@ export default function Layout({ children }: LayoutProps) {
           exit={{ opacity: 0, y: -20 }}
           transition={{ duration: 0.3 }}
         >
-          {children}
-          <footer>
-            <p>&copy; 2025 Baayno Website</p>
-          </footer>
+          <main>
+            {children}
+            <footer>
+              <p>&copy; 2025 Baayno Website</p>
+            </footer>
+          </main>
         </motion.div>
       </AnimatePresence>
     </div>


### PR DESCRIPTION
## Summary
- Wrap page content and footer in a semantic `<main>` element within the animated layout
- Scope IntersectionObserver to sections inside `<main>` to preserve fade-in animations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ac947eca84832e9304248c37cb9414