### PR TITLE
Reset media loop index on source change

### DIFF
--- a/components/hero/BookbinderyHero.tsx
+++ b/components/hero/BookbinderyHero.tsx
@@ -32,11 +32,15 @@ function MediaLoop(
   const useCarousel = forceCarousel || !firstIsVideo;
 
   useEffect(() => {
+    setIndex(0);
+  }, [sources]);
+
+  useEffect(() => {
     if (onlyOne || !useCarousel) return;
     if (sources.length === 0) return;
     const id = setInterval(() => setIndex((i) => (i + 1) % sources.length), interval);
     return () => clearInterval(id);
-  }, [interval, onlyOne, useCarousel, sources.length]);
+  }, [interval, onlyOne, useCarousel, sources]);
 
   // Fallback for empty sources
   if (!sources || sources.length === 0) {


### PR DESCRIPTION
## Summary
- reset media carousel index when source list updates
- trigger media loop effect on source changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ac96e4b908832eabb496d44fcb5012